### PR TITLE
Adding Intents support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ be found at [https://hexdocs.pm/mobius](https://hexdocs.pm/mobius).
 
 ## Missing features
 
+- [ ] Rewrite the demo_bot so we can run it from iex
 - [ ] System test which starts a real bot and tries as many endpoints as possible
 - [ ] Intents
 - [ ] Implement all missing api endpoints

--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ be found at [https://hexdocs.pm/mobius](https://hexdocs.pm/mobius).
 - [ ] Implement a cache of objects
 - [ ] Sanitize event data
 - [ ] Struct-ify data
+- [ ] Updating intents without closing all shards at once

--- a/demo_bot.ex
+++ b/demo_bot.ex
@@ -52,7 +52,7 @@ defmodule DemoBot do
     end
 
     Bot.unsubscribe_events(state.bot)
-    Bot.subscribe_events(state.bot, [:MESSAGE_CREATE, :GUILD_CREATE])
+    Bot.subscribe_events(state.bot, [:MESSAGE_CREATE])
 
     Bot.update_status(state.bot, %Mobius.Models.Status{game: %{"type" => 0, "name" => "Ready!"}})
 

--- a/demo_bot.ex
+++ b/demo_bot.ex
@@ -37,7 +37,8 @@ defmodule DemoBot do
 
   @spec init(keyword) :: {:ok, state(), {:continue, atom}}
   def init(opts) do
-    bot = Bot.start_bot(:demo_bot, Keyword.fetch!(opts, :token))
+    intents = MapSet.new([:guilds, :guild_messages, :direct_messages])
+    bot = Bot.start_bot(:demo_bot, Keyword.fetch!(opts, :token), intents)
 
     Bot.subscribe_events(bot, [:READY])
 
@@ -51,7 +52,7 @@ defmodule DemoBot do
     end
 
     Bot.unsubscribe_events(state.bot)
-    Bot.subscribe_events(state.bot, [:MESSAGE_CREATE])
+    Bot.subscribe_events(state.bot, [:MESSAGE_CREATE, :GUILD_CREATE])
 
     Bot.update_status(state.bot, %Mobius.Models.Status{game: %{"type" => 0, "name" => "Ready!"}})
 

--- a/lib/mobius/application.ex
+++ b/lib/mobius/application.ex
@@ -29,7 +29,7 @@ defmodule Mobius.Application do
     :ok = DynamicSupervisor.terminate_child(@ratelimit_supervisor, pid)
   end
 
-  @spec start_bot(keyword) :: {:ok, Mobius.Bot.t()} | :already_started | {:error, any}
+  @spec start_bot(keyword) :: {:ok, Mobius.Bot.t()} | {:error, any}
   def start_bot(opts) do
     shard_range = Keyword.fetch!(opts, :shard_range)
     id = Keyword.fetch!(opts, :id)
@@ -59,9 +59,9 @@ defmodule Mobius.Application do
         id: id
       )
 
-    with {:ok, _pid} <- Supervisor.start_child(@supervisor, spec) do
-      Logger.debug("Started bot: #{inspect(bot)}")
-      {:ok, bot}
+    case Supervisor.start_child(@supervisor, spec) do
+      {:ok, _pid} -> {:ok, bot}
+      {:error, error} -> error
     end
   end
 

--- a/lib/mobius/bot.ex
+++ b/lib/mobius/bot.ex
@@ -124,6 +124,24 @@ defmodule Mobius.Bot do
   end
 
   @doc """
+  Updates the intents in each shard
+
+  **Warning**
+  This function causes all shards to disconnect from the gateway and attempt to reconnect with the new intents.
+  If you have more than one shard, this takes 5 seconds per shard after the first one!
+  During this time, you won't receive events from guilds on shards which haven't reconnected yet and
+  you won't be able to interact with those shards in any way either.
+  """
+  @spec update_intents(Bot.t(), Intents.intents()) :: list(:ok)
+  def update_intents(bot, intents) do
+    for shard_num <- bot.shard_range do
+      bot
+      |> gateway_name(shard_num)
+      |> Gateway.update_intents(intents)
+    end
+  end
+
+  @doc """
   Set the bot's new `Mobius.Models.Status`
 
   Returns an ordered list where the nth element is the return value of the nth shard

--- a/lib/mobius/bot.ex
+++ b/lib/mobius/bot.ex
@@ -63,16 +63,16 @@ defmodule Mobius.Bot do
       "wss://" <> url = info.url
       # TODO: Consider `info.session_start_limit` to prevent abuse
 
-      with {:ok, bot} <-
-             Mobius.Application.start_bot(
-               shard_range: shard_range,
-               id: id,
-               intents: intents,
-               url: url,
-               token: token
-             ) do
-        %__MODULE__{bot | client: client, ratelimit_server: ratelimit_server}
-      end
+      {:ok, bot} =
+        Mobius.Application.start_bot(
+          shard_range: shard_range,
+          id: id,
+          intents: intents,
+          url: url,
+          token: token
+        )
+
+      %__MODULE__{bot | client: client, ratelimit_server: ratelimit_server}
     end
   end
 

--- a/lib/mobius/bot.ex
+++ b/lib/mobius/bot.ex
@@ -36,7 +36,7 @@ defmodule Mobius.Bot do
   alias Mobius.Api
   alias Mobius.Api.Client
   alias Mobius.Shard.Gateway
-  alias Mobius.Models.{Status, Snowflake}
+  alias Mobius.Models.{Status, Snowflake, Intents}
 
   @typedoc "Return value for ratelimited asynchronous function calls"
   @type ratelimited :: {:error, :ratelimited}
@@ -51,7 +51,7 @@ defmodule Mobius.Bot do
 
   This function is not idempotent, two calls with the same arguments will not return the exact same struct.
   """
-  @spec start_bot(atom, String.t(), Mobius.Intents.intents()) ::
+  @spec start_bot(atom, String.t(), Intents.intents()) ::
           Bot.t() | {:error, :unauthorized_token | :ratelimited}
   def start_bot(id, token, intents) do
     # TODO: Figure out how to cleanup the ratelimit server in case of errors

--- a/lib/mobius/bot.ex
+++ b/lib/mobius/bot.ex
@@ -110,6 +110,20 @@ defmodule Mobius.Bot do
   end
 
   @doc """
+  Returns the current intents in each shard in an ordered list
+
+  The nth element of the list is the intents of the nth shard
+  """
+  @spec get_intents(Bot.t()) :: list(Intents.intents())
+  def get_intents(bot) do
+    for shard_num <- bot.shard_range do
+      bot
+      |> gateway_name(shard_num)
+      |> Gateway.get_intents()
+    end
+  end
+
+  @doc """
   Set the bot's new `Mobius.Models.Status`
 
   Returns an ordered list where the nth element is the return value of the nth shard

--- a/lib/mobius/intents.ex
+++ b/lib/mobius/intents.ex
@@ -1,0 +1,95 @@
+defmodule Mobius.Intents do
+  @moduledoc false
+
+  require Logger
+
+  @type intents :: MapSet.t(atom)
+
+  # Order is important, use nil for missing bitflags
+  @intents [
+    :guilds,
+    :guild_members,
+    :guild_bans,
+    :guild_integrations,
+    :guild_webhooks,
+    :guild_invites,
+    :guild_voice_states,
+    :guild_presences,
+    :guild_messages,
+    :guild_message_reactions,
+    :guild_message_typing,
+    :direct_messages,
+    :direct_message_reactions,
+    :direct_message_typing
+  ]
+
+  @privileged [:guild_members, :guild_presences]
+
+  # Must have at least one of the intents to receive the event
+  @event_intents [
+    HELLO: [],
+    READY: [],
+    RESUMED: [],
+    RECONNECT: [],
+    INVALID_SESSION: [],
+    CHANNEL_CREATE: [:guilds],
+    CHANNEL_UPDATE: [:guilds],
+    CHANNEL_DELETE: [:guilds],
+    CHANNEL_PINS_UPDATE: [:guilds],
+    GUILD_CREATE: [:guilds],
+    GUILD_UPDATE: [:guilds],
+    GUILD_DELETE: [:guilds],
+    GUILD_BAN_ADD: [:guild_bans],
+    GUILD_BAN_REMOVE: [:guild_bans],
+    GUILD_EMOJIS_UPDATE: [:guild_emojis],
+    GUILD_INTEGRATIONS_UPDATE: [:guild_integrations],
+    GUILD_MEMBER_ADD: [:guild_members],
+    GUILD_MEMBER_REMOVE: [:guild_members],
+    GUILD_MEMBER_UPDATE: [:guild_members],
+    GUILD_MEMBERS_CHUNK: [],
+    GUILD_ROLE_CREATE: [:guilds],
+    GUILD_ROLE_UPDATE: [:guilds],
+    GUILD_ROLE_DELETE: [:guilds],
+    INVITE_CREATE: [:guild_invites],
+    INVITE_DELETE: [:guild_invites],
+    MESSAGE_CREATE: [:guild_messages, :direct_messages],
+    MESSAGE_UPDATE: [:guild_messages, :direct_messages],
+    MESSAGE_DELETE: [:guild_messages, :direct_messages],
+    MESSAGE_DELETE_BULK: [:guild_messages, :direct_messages],
+    MESSAGE_REACTION_ADD: [:guild_message_reactions, :direct_message_reactions],
+    MESSAGE_REACTION_REMOVE: [:guild_message_reactions, :direct_message_reactions],
+    MESSAGE_REACTION_REMOVE_ALL: [:guild_message_reactions, :direct_message_reactions],
+    MESSAGE_REACTION_REMOVE_EMOJI: [:guild_message_reactions, :direct_message_reactions],
+    PRESENCE_UPDATE: [:guild_presences],
+    TYPING_START: [:guild_message_typing, :direct_message_typing],
+    USER_UPDATE: [],
+    VOICE_STATE_UPDATE: [:guild_voice_states],
+    VOICE_SERVER_UPDATE: [],
+    WEBHOOKS_UPDATE: [:guild_webhooks]
+  ]
+
+  @spec intents_to_integer(intents()) :: integer
+  def intents_to_integer(intents), do: Mobius.Utils.create_bitflags(intents, @intents)
+
+  @spec warn_privileged_intents(intents()) :: any
+  def warn_privileged_intents(intents) do
+    for intent <- @privileged, intent in intents do
+      Logger.warn(
+        "You are using the privileged intent #{inspect(intent)} but don't seem to have it enabled"
+      )
+    end
+  end
+
+  @spec has_intent_for_event?(atom, list(atom)) :: boolean
+  def has_intent_for_event?(event_name, intents)
+
+  for {event_name, required_intents} <- @event_intents do
+    if required_intents == [] do
+      def has_intent_for_event?(unquote(event_name), _intents), do: true
+    else
+      def has_intent_for_event?(unquote(event_name), intents) do
+        Enum.any?(unquote(required_intents), &(&1 in intents))
+      end
+    end
+  end
+end

--- a/lib/mobius/intents.ex
+++ b/lib/mobius/intents.ex
@@ -80,6 +80,13 @@ defmodule Mobius.Intents do
     end
   end
 
+  @spec events_for_intents(intents()) :: list(atom)
+  def events_for_intents(intents) do
+    @intents
+    |> Stream.map(fn {name, _} -> name end)
+    |> Enum.filter(&has_intent_for_event?(&1, intents))
+  end
+
   @spec has_intent_for_event?(atom, list(atom)) :: boolean
   def has_intent_for_event?(event_name, intents)
 

--- a/lib/mobius/intents.ex
+++ b/lib/mobius/intents.ex
@@ -10,6 +10,7 @@ defmodule Mobius.Intents do
     :guilds,
     :guild_members,
     :guild_bans,
+    :guild_emojis,
     :guild_integrations,
     :guild_webhooks,
     :guild_invites,
@@ -68,6 +69,9 @@ defmodule Mobius.Intents do
     WEBHOOKS_UPDATE: [:guild_webhooks]
   ]
 
+  @spec all_intents() :: intents()
+  def all_intents, do: MapSet.new(@intents)
+
   @spec intents_to_integer(intents()) :: integer
   def intents_to_integer(intents), do: Mobius.Utils.create_bitflags(intents, @intents)
 
@@ -82,7 +86,7 @@ defmodule Mobius.Intents do
 
   @spec events_for_intents(intents()) :: list(atom)
   def events_for_intents(intents) do
-    @intents
+    @event_intents
     |> Stream.map(fn {name, _} -> name end)
     |> Enum.filter(&has_intent_for_event?(&1, intents))
   end

--- a/lib/mobius/models/intents.ex
+++ b/lib/mobius/models/intents.ex
@@ -1,4 +1,4 @@
-defmodule Mobius.Intents do
+defmodule Mobius.Models.Intents do
   @moduledoc false
 
   require Logger

--- a/lib/mobius/models/permissions.ex
+++ b/lib/mobius/models/permissions.ex
@@ -43,6 +43,7 @@ defmodule Mobius.Models.Permissions do
   @spec has_permission?(atom, permission()) :: boolean
   @spec mfa_required?(atom) :: boolean
   @spec permission_applies?(atom, :text | :voice) :: boolean
+
   for {name, bit, applicable_channel_types, mfa_required?} <- @permissions do
     def has_permission?(unquote(name), value), do: (value &&& unquote(bit)) == unquote(bit)
     def mfa_required?(unquote(name)), do: unquote(mfa_required?)
@@ -52,5 +53,10 @@ defmodule Mobius.Models.Permissions do
     end
 
     def permission_applies?(unquote(name), _channel_type), do: false
+  end
+
+  @spec permission_from_names(MapSet.t(atom)) :: permission()
+  def permission_from_names(names) do
+    Mobius.Utils.create_bitflags(names, Enum.map(@permissions, &elem(&1, 0)))
   end
 end

--- a/lib/mobius/shard/gateway.ex
+++ b/lib/mobius/shard/gateway.ex
@@ -36,6 +36,16 @@ defmodule Mobius.Shard.Gateway do
     GenServer.call(gateway, :get_ping)
   end
 
+  @spec get_intents(GenServer.server()) :: Intents.intents()
+  def get_intents(gateway) do
+    GenServer.call(gateway, :get_intents)
+  end
+
+  @spec update_intents(GenServer.server(), Intents.intents()) :: :ok
+  def update_intents(gateway, intents) do
+    GenServer.call(gateway, {:update_intents, intents})
+  end
+
   # TODO: Revisit once intents are implemented (there's additional limits)
   def request_guild_members(gateway, guild_ids, user_ids, presences?) do
     MemberRequest.request_with_ids(gateway, guild_ids, user_ids, presences?)
@@ -184,6 +194,15 @@ defmodule Mobius.Shard.Gateway do
 
   def handle_call(:get_ping, _from, %GatewayState{heartbeat_ping: ping} = state) do
     {:reply, ping, state}
+  end
+
+  def handle_call(:get_intents, _from, %GatewayState{intents: intents} = state) do
+    {:reply, intents, state}
+  end
+
+  def handle_call({:update_intents, intents}, _from, %GatewayState{} = state) do
+    Socket.close(state.socket_pid)
+    {:reply, :ok, %GatewayState{state | session_id: nil, intents: intents}}
   end
 
   def handle_call({:update_status, status}, _from, %GatewayState{} = state) do

--- a/lib/mobius/shard/gateway.ex
+++ b/lib/mobius/shard/gateway.ex
@@ -79,6 +79,7 @@ defmodule Mobius.Shard.Gateway do
       member_request_pids: %{},
       bot_id: Keyword.fetch!(opts, :bot_id),
       token: Keyword.fetch!(opts, :token),
+      intents: Keyword.fetch!(opts, :intents),
       shard_num: shard_num,
       shard_count: Keyword.fetch!(opts, :shard_count),
       heartbeat_timer: nil,
@@ -116,6 +117,7 @@ defmodule Mobius.Shard.Gateway do
   def handle_info({:socket_closed, close_num, reason}, state) do
     {close_reason, what_can_do} = ErrorCodes.translate_gateway_error(close_num)
     Logger.warn("Socket closed (#{close_num}: #{close_reason}) #{reason}")
+    if close_num == 4014, do: Mobius.Intents.warn_privileged_intents(state.intents)
     state = stop_heartbeat(state)
 
     case what_can_do do

--- a/lib/mobius/shard/gateway.ex
+++ b/lib/mobius/shard/gateway.ex
@@ -2,6 +2,7 @@ defmodule Mobius.Shard.Gateway do
   @moduledoc false
 
   alias Mobius.{ErrorCodes, Utils}
+  alias Mobius.Models.Intents
 
   alias Mobius.Shard.{
     GatewayState,
@@ -117,7 +118,7 @@ defmodule Mobius.Shard.Gateway do
   def handle_info({:socket_closed, close_num, reason}, state) do
     {close_reason, what_can_do} = ErrorCodes.translate_gateway_error(close_num)
     Logger.warn("Socket closed (#{close_num}: #{close_reason}) #{reason}")
-    if close_num == 4014, do: Mobius.Intents.warn_privileged_intents(state.intents)
+    if close_num == 4014, do: Intents.warn_privileged_intents(state.intents)
     state = stop_heartbeat(state)
 
     case what_can_do do

--- a/lib/mobius/shard/gateway_state.ex
+++ b/lib/mobius/shard/gateway_state.ex
@@ -104,7 +104,7 @@ defmodule Mobius.Shard.GatewayState do
           member_request_pids: member_request_pids,
           bot_id: bot_id,
           token: token,
-          intents: Mobius.Intents.intents(),
+          intents: Mobius.Models.Intents.intents(),
           shard_num: shard_number,
           shard_count: shard_count,
           heartbeat_timer: heartbeat_timer,

--- a/lib/mobius/shard/gateway_state.ex
+++ b/lib/mobius/shard/gateway_state.ex
@@ -18,6 +18,7 @@ defmodule Mobius.Shard.GatewayState do
     # Settings
     :bot_id,
     :token,
+    :intents,
     # Shards
     :shard_num,
     :shard_count,
@@ -103,6 +104,7 @@ defmodule Mobius.Shard.GatewayState do
           member_request_pids: member_request_pids,
           bot_id: bot_id,
           token: token,
+          intents: Mobius.Intents.intents(),
           shard_num: shard_number,
           shard_count: shard_count,
           heartbeat_timer: heartbeat_timer,

--- a/lib/mobius/shard/member_request.ex
+++ b/lib/mobius/shard/member_request.ex
@@ -12,6 +12,7 @@ defmodule Mobius.Shard.MemberRequest do
 
   # TODO: What to do with the not_founds?
   # TODO: Presences are currently unused
+  # TODO: Figure out a way to timeout the chunk task if the stream is never consumed
 
   require Logger
 

--- a/lib/mobius/shard/member_request.ex
+++ b/lib/mobius/shard/member_request.ex
@@ -4,23 +4,34 @@ defmodule Mobius.Shard.MemberRequest do
   # A module for managing everything about guild member requests and their chunks
   # This basically helps the gateway organize the received chunks into a Stream
 
+  # Relevant documentation: https://discord.com/developers/docs/topics/gateway#request-guild-members
+
+  # The docs say guild_id can be a snowflake or an array of snowflakes, but
+  # because we're using intents, it can only be a single snowflake
+  # It also says "snowflake", but really it has to be a string otherwise it never sends chunks
+
   # TODO: What to do with the not_founds?
   # TODO: Presences are currently unused
 
   require Logger
 
   alias Mobius.TimeoutError
+  alias Mobius.Models.Intents
 
   @timeout Application.compile_env(:mobius, :member_request_timeout_ms, 10_000)
 
+  @type errors :: {:error, :ratelimited | String.t()}
+  @type out :: Stream.t() | errors()
+
   # Request specific members in specific guilds
+  @spec request_with_ids(GenServer.server(), String.t(), list(String.t()), boolean) :: out()
   def request_with_ids(_, _, user_ids, _) when length(user_ids) > 100 do
     raise "Cannot ask for more than 100 members"
   end
 
-  def request_with_ids(gateway, guild_ids, user_ids, presences?) do
+  def request_with_ids(gateway, guild_id, user_ids, presences?) do
     payload = %{
-      "guild_id" => guild_ids,
+      "guild_id" => guild_id,
       "user_ids" => user_ids,
       "presences" => presences?
     }
@@ -28,6 +39,7 @@ defmodule Mobius.Shard.MemberRequest do
     make_stream(gateway, payload)
   end
 
+  @spec request_with_prefix(GenServer.server(), String.t(), String.t(), integer, boolean) :: out()
   def request_with_prefix(_, _, _, limit, _) when limit > 100 do
     raise "Cannot ask for more than 100 members"
   end
@@ -36,9 +48,9 @@ defmodule Mobius.Shard.MemberRequest do
     raise "Cannot request for all members when using a prefix"
   end
 
-  def request_with_prefix(gateway, guild_ids, name_prefix, limit, presences?) do
+  def request_with_prefix(gateway, guild_id, name_prefix, limit, presences?) do
     payload = %{
-      "guild_id" => guild_ids,
+      "guild_id" => guild_id,
       "query" => name_prefix,
       "limit" => limit,
       "presences" => presences?
@@ -47,16 +59,31 @@ defmodule Mobius.Shard.MemberRequest do
     make_stream(gateway, payload)
   end
 
+  @spec check_intents(map, Intents.intents()) :: :ok | {:error, String.t()}
+  def check_intents(payload, intents) do
+    cond do
+      payload["presences"] and not MapSet.member?(intents, :guild_presences) ->
+        {:error, "Cannot request presences without the :guild_presences intent"}
+
+      payload["query"] == "" and not MapSet.member?(intents, :guild_members) ->
+        {:error, "Cannot request all members (empty prefix) without the :guild_members intent"}
+
+      true ->
+        :ok
+    end
+  end
+
+  @spec make_stream(GenServer.server(), map) :: out()
   def make_stream(gateway, payload) do
     # Start a process which keeps track of the chunks received
     {:ok, pid} = Task.start_link(&chunk_holder_task/0)
     # Tell the Socket it can make the request and keep the nonce to tell it when we're done
     GenServer.call(gateway, {:member_request, pid, payload})
     |> case do
-      {:error, :ratelimited} ->
+      {:error, error} ->
         # Stop the process to cleanup
         send(pid, :shutdown)
-        {:error, :ratelimited}
+        {:error, error}
 
       nonce ->
         Stream.resource(

--- a/lib/mobius/shard/opcodes.ex
+++ b/lib/mobius/shard/opcodes.ex
@@ -3,6 +3,7 @@ defmodule Mobius.Shard.Opcodes do
 
   require Logger
 
+  alias Mobius.Models.Intents
   alias Mobius.Shard.GatewayState
 
   # Gateway payloads
@@ -15,11 +16,11 @@ defmodule Mobius.Shard.Opcodes do
   @spec identify(GatewayState.t()) :: map
   def identify(%GatewayState{} = state) do
     {family, name} = :os.type()
-    intents = Mobius.Intents.intents_to_integer(state.intents)
+    intents = Intents.intents_to_integer(state.intents)
 
     Logger.debug(
       "Intended events for #{inspect(state.intents)} (#{intents}): " <>
-        "#{inspect(Mobius.Intents.events_for_intents(state.intents))}"
+        "#{inspect(Intents.events_for_intents(state.intents))}"
     )
 
     %{

--- a/lib/mobius/shard/opcodes.ex
+++ b/lib/mobius/shard/opcodes.ex
@@ -15,9 +15,12 @@ defmodule Mobius.Shard.Opcodes do
   @spec identify(GatewayState.t()) :: map
   def identify(%GatewayState{} = state) do
     {family, name} = :os.type()
+    intents = Mobius.Intents.intents_to_integer(state.intents)
 
-    Logger.debug("Identifying with intents #{inspect(state.intents)}")
-    Logger.debug("Intended events: #{inspect(Mobius.Intents.events_for_intents(state.intents))}")
+    Logger.debug(
+      "Intended events for #{inspect(state.intents)} (#{intents}): " <>
+        "#{inspect(Mobius.Intents.events_for_intents(state.intents))}"
+    )
 
     %{
       "token" => state.token,
@@ -29,7 +32,7 @@ defmodule Mobius.Shard.Opcodes do
       # Compression here can't be enabled because we're using ETF
       "compress" => false,
       "shard" => [state.shard_num, state.shard_count],
-      "intents" => Mobius.Intents.intents_to_integer(state.intents)
+      "intents" => intents
     }
     |> serialize(:identify)
   end

--- a/test/mobius/shard/member_request_test.exs
+++ b/test/mobius/shard/member_request_test.exs
@@ -23,6 +23,19 @@ defmodule Mobius.Shard.MemberRequestTest do
       end
     end
 
+    @tag intents: MapSet.new()
+    test "returns an error when asking for presences without the intent", ctx do
+      {:error, error} =
+        MemberRequest.request_with_ids(
+          ctx.gateway,
+          random_snowflake(),
+          [random_snowflake()],
+          true
+        )
+
+      assert error == "Cannot request presences without the :guild_presences intent"
+    end
+
     test "calls the socket with the proper payload", %{gateway: gateway_pid} do
       guild_id = random_snowflake()
       user_id = random_snowflake()
@@ -55,6 +68,35 @@ defmodule Mobius.Shard.MemberRequestTest do
       assert_raise RuntimeError, "Cannot request for all members when using a prefix", fn ->
         MemberRequest.request_with_prefix(nil, random_snowflake(), "a", 0, false)
       end
+    end
+
+    @tag intents: MapSet.new()
+    test "returns an error when asking for presences without the intent", ctx do
+      {:error, error} =
+        MemberRequest.request_with_prefix(
+          ctx.gateway,
+          random_snowflake(),
+          "a",
+          50,
+          true
+        )
+
+      assert error == "Cannot request presences without the :guild_presences intent"
+    end
+
+    @tag intents: MapSet.new()
+    test "returns an error when asking for all members without the intent", ctx do
+      {:error, error} =
+        MemberRequest.request_with_prefix(
+          ctx.gateway,
+          random_snowflake(),
+          "",
+          0,
+          false
+        )
+
+      assert error ==
+               "Cannot request all members (empty prefix) without the :guild_members intent"
     end
 
     test "calls the socket with the proper payload", %{gateway: gateway_pid} do

--- a/test/mobius/shard/opcodes_test.exs
+++ b/test/mobius/shard/opcodes_test.exs
@@ -3,6 +3,7 @@ defmodule Mobius.Shard.OpcodesTest do
 
   import Mobius.Fixtures
 
+  alias Mobius.Models.Intents
   alias Mobius.Shard.{Opcodes, GatewayState}
 
   describe "heartbeat/1" do
@@ -27,7 +28,7 @@ defmodule Mobius.Shard.OpcodesTest do
 
   describe "identify/1" do
     test "serializes with the right opcode" do
-      %GatewayState{}
+      %GatewayState{intents: Intents.all_intents()}
       |> Opcodes.identify()
       |> assert_opcode(:identify)
     end
@@ -38,6 +39,7 @@ defmodule Mobius.Shard.OpcodesTest do
       shard = 1
       shard_count = 2
       token = random_hex(8)
+      intents = Intents.all_intents()
 
       expected_value = %{
         "token" => token,
@@ -48,11 +50,11 @@ defmodule Mobius.Shard.OpcodesTest do
         },
         "compress" => false,
         "shard" => [shard, shard_count],
-        "guild_subscriptions" => false
+        "intents" => Intents.intents_to_integer(intents)
       }
 
       data =
-        %GatewayState{shard_num: shard, shard_count: shard_count, token: token}
+        %GatewayState{shard_num: shard, shard_count: shard_count, token: token, intents: intents}
         |> Opcodes.identify()
         |> deserialize()
         |> elem(1)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -5,6 +5,7 @@ defmodule Mobius.Fixtures do
 
   alias Mobius.PubSub
   alias Mobius.Api.Client
+  alias Mobius.Models.Intents
   alias Mobius.Shard.Gateway
   alias Mobius.Shard.Ratelimiter
 
@@ -28,6 +29,7 @@ defmodule Mobius.Fixtures do
          gateway_url: "",
          name: :"TestGateway #{shard_num}",
          bot_id: Integer.to_string(shard_num),
+         intents: Intents.all_intents(),
          token: token,
          shard_num: shard_num,
          shard_count: 1,

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -29,7 +29,7 @@ defmodule Mobius.Fixtures do
          gateway_url: "",
          name: :"TestGateway #{shard_num}",
          bot_id: Integer.to_string(shard_num),
-         intents: Intents.all_intents(),
+         intents: Map.get(context, :intents, Intents.all_intents()),
          token: token,
          shard_num: shard_num,
          shard_count: 1,


### PR DESCRIPTION
See https://discord.com/developers/docs/topics/gateway#gateway-intents for documentation on Discord's intents

## New public functions
- `Mobius.Bot.get_intents/1` reads the intents from each shard
- `Mobius.Bot.update_intents/2` updates the intent on each shard

## New modules
- `Mobius.Models.Intents` functions for manipulating intents

## Other changes
- Added checks in `Mobius.Shard.MemberRequest` for verifying the intents associated with specific features
- Added a warning when the gateway socket closes with "Disallowed intent(s)" if `:guild_members` or `:guild_presences` is used
- A dozen of spec fixes and documentation fixes.

## Test coverage
Now at 87.0% (up from 86.7%)