### PR TITLE
refactor: Waiting for required services in init/1

### DIFF
--- a/lib/mobius/application.ex
+++ b/lib/mobius/application.ex
@@ -21,6 +21,11 @@ defmodule Mobius.Application do
     Supervisor.start_link(children, strategy: :one_for_one, name: Mobius.Supervisor)
   end
 
+  def reset_services do
+    :ok = Application.stop(:mobius)
+    :ok = Application.start(:mobius)
+  end
+
   defp dynamic_supervisor(name),
     do: {DynamicSupervisor, name: name, strategy: :one_for_one, max_restarts: 1}
 

--- a/lib/mobius/services/shard.ex
+++ b/lib/mobius/services/shard.ex
@@ -75,7 +75,9 @@ defmodule Mobius.Services.Shard do
       shard: shard
     }
 
-    {:ok, pid} = Socket.start_socket(state.shard, Keyword.fetch!(opts, :url), %{"v" => @gateway_version})
+    url = Keyword.fetch!(opts, :url)
+    {:ok, pid} = Socket.start_socket(state.shard, url, %{"v" => @gateway_version})
+
     Logger.debug("Started socket on #{inspect(pid)}")
 
     {:ok, state}

--- a/lib/mobius/services/shard.ex
+++ b/lib/mobius/services/shard.ex
@@ -65,7 +65,7 @@ defmodule Mobius.Services.Shard do
   end
 
   @impl GenServer
-  @spec init(keyword) :: {:ok, state(), {:continue, any}}
+  @spec init(keyword) :: {:ok, state()}
   def init(opts) do
     %ShardInfo{} = shard = Keyword.fetch!(opts, :shard)
     Logger.debug("Started shard on pid #{inspect(self())}")
@@ -75,15 +75,10 @@ defmodule Mobius.Services.Shard do
       shard: shard
     }
 
-    {:ok, state, {:continue, {:start_socket, Keyword.fetch!(opts, :url)}}}
-  end
-
-  @impl GenServer
-  @spec handle_continue({:start_socket, String.t()}, state()) :: {:noreply, state()}
-  def handle_continue({:start_socket, url}, state) do
-    {:ok, pid} = Socket.start_socket(state.shard, url, %{"v" => @gateway_version})
+    {:ok, pid} = Socket.start_socket(state.shard, Keyword.fetch!(opts, :url), %{"v" => @gateway_version})
     Logger.debug("Started socket on #{inspect(pid)}")
-    {:noreply, state}
+
+    {:ok, state}
   end
 
   @impl GenServer

--- a/test/mobius/actions/status_test.exs
+++ b/test/mobius/actions/status_test.exs
@@ -8,6 +8,7 @@ defmodule Mobius.Actions.StatusTest do
   alias Mobius.Core.Opcode
   alias Mobius.Stubs
 
+  setup :reset_services
   setup :handshake_shard
   setup :stub_socket
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -10,6 +10,10 @@ defmodule Mobius.Fixtures do
 
   @shard ShardInfo.new(number: 0, count: 1)
 
+  def reset_services(_context) do
+    Mobius.Application.reset_services()
+  end
+
   def stub_socket(_context) do
     @shard
     |> Socket.via()


### PR DESCRIPTION
This makes the startup of services a lot more deterministic and synchronous which in turn makes tests a lot easier to work with.

The idea here is that supervisors were assuming the services were ready as soon as init/1 returned, but because of the `:continue` which started the other services, it wasn't true. This meant tests using services had no way of knowing when the services were actually ready for usage which would just cause lots of errors down the stream.

For `bot.ex`, everything was moved around so the diff is kind of hard to read. It might be easier to simply read its new content instead of looking at the diff.