### PR TITLE
feat: Store shard infos on ETS

### DIFF
--- a/lib/mobius/application.ex
+++ b/lib/mobius/application.ex
@@ -8,6 +8,7 @@ defmodule Mobius.Application do
   @spec start(any, list) :: {:ok, pid}
   def start(_type, _args) do
     children = [
+      {Mobius.Services.ETSShelf, []},
       registry(Mobius.Registry.Heartbeat),
       registry(Mobius.Registry.Shard),
       registry(Mobius.Registry.Socket),

--- a/lib/mobius/core/shard_list.ex
+++ b/lib/mobius/core/shard_list.ex
@@ -1,0 +1,35 @@
+defmodule Mobius.Core.ShardList do
+  @moduledoc false
+
+  alias Mobius.Core.ShardInfo
+
+  @spec table_options() :: [atom]
+  def table_options do
+    [:ordered_set, :protected]
+  end
+
+  @spec list_shards(:ets.tab()) :: [ShardInfo.t()]
+  def list_shards(table) do
+    shards = :ets.match(table, {:"$1", :_})
+    List.flatten(shards)
+  end
+
+  @spec are_all_shards_ready?(:ets.tab()) :: boolean
+  def are_all_shards_ready?(table) do
+    # :ets.fun2ms(fn {_, state} when state != :ready -> state end)
+    spec = [{{:_, :"$1"}, [{:"/=", :"$1", :ready}], [:"$1"]}]
+    :ets.select(table, spec) == []
+  end
+
+  @spec add_shard(:ets.tab(), ShardInfo.t()) :: ShardInfo.t()
+  def add_shard(table, %ShardInfo{} = shard) do
+    :ets.insert(table, {shard, :starting})
+    shard
+  end
+
+  @spec update_shard_ready(:ets.tab(), ShardInfo.t()) :: ShardInfo.t()
+  def update_shard_ready(table, %ShardInfo{} = shard) do
+    :ets.insert(table, {shard, :ready})
+    shard
+  end
+end

--- a/lib/mobius/core/shard_list.ex
+++ b/lib/mobius/core/shard_list.ex
@@ -19,6 +19,7 @@ defmodule Mobius.Core.ShardList do
   @doc "True if all shards have state `:ready`"
   @spec are_all_shards_ready?(:ets.tab()) :: boolean
   def are_all_shards_ready?(table) do
+    # The match spec was generated with the following line in iex:
     # :ets.fun2ms(fn {_, state} when state != :ready -> state end)
     spec = [{{:_, :"$1"}, [{:"/=", :"$1", :ready}], [:"$1"]}]
     :ets.select(table, spec) == []

--- a/lib/mobius/core/shard_list.ex
+++ b/lib/mobius/core/shard_list.ex
@@ -3,17 +3,20 @@ defmodule Mobius.Core.ShardList do
 
   alias Mobius.Core.ShardInfo
 
+  @doc "Options for the ETS table creation"
   @spec table_options() :: [atom]
   def table_options do
     [:ordered_set, :protected]
   end
 
+  @doc "Lists all shards regardless of state"
   @spec list_shards(:ets.tab()) :: [ShardInfo.t()]
   def list_shards(table) do
     shards = :ets.match(table, {:"$1", :_})
     List.flatten(shards)
   end
 
+  @doc "True if all shards have state `:ready`"
   @spec are_all_shards_ready?(:ets.tab()) :: boolean
   def are_all_shards_ready?(table) do
     # :ets.fun2ms(fn {_, state} when state != :ready -> state end)
@@ -21,12 +24,14 @@ defmodule Mobius.Core.ShardList do
     :ets.select(table, spec) == []
   end
 
+  @doc "Adds a shard to the list with state `:starting`"
   @spec add_shard(:ets.tab(), ShardInfo.t()) :: ShardInfo.t()
   def add_shard(table, %ShardInfo{} = shard) do
     :ets.insert(table, {shard, :starting})
     shard
   end
 
+  @doc "Updates a shard's state to `:ready`"
   @spec update_shard_ready(:ets.tab(), ShardInfo.t()) :: ShardInfo.t()
   def update_shard_ready(table, %ShardInfo{} = shard) do
     :ets.insert(table, {shard, :ready})

--- a/lib/mobius/services/bot.ex
+++ b/lib/mobius/services/bot.ex
@@ -5,9 +5,12 @@ defmodule Mobius.Services.Bot do
 
   alias Mobius.Core.ShardInfo
   alias Mobius.Rest
+  alias Mobius.Services.ETSShelf
   alias Mobius.Services.Shard
 
   require Logger
+
+  @ets_table :mobius_bot
 
   @typep state :: %{
            client: Rest.Client.client(),
@@ -43,6 +46,8 @@ defmodule Mobius.Services.Bot do
       ready_shards: MapSet.new(),
       token: token
     }
+
+    :ok = ETSShelf.create_table(@ets_table, [:set, :protected])
 
     {:ok, state}
   end

--- a/lib/mobius/services/ets_shelf.ex
+++ b/lib/mobius/services/ets_shelf.ex
@@ -1,0 +1,59 @@
+defmodule Mobius.Services.ETSShelf do
+  @moduledoc false
+
+  use GenServer
+
+  @timeout 1_000
+
+  @spec start_link(keyword) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec create_table(atom, [atom | tuple]) :: :ok | {:error, :ets_error}
+  def create_table(name, opts) when is_atom(name) do
+    # Creates the table or gives it back if the server already owns it
+    with :ok <- GenServer.call(__MODULE__, {:create, name, self(), opts}) do
+      receive do
+        {:"ETS-TRANSFER", ^name, _pid, _data} -> :ok
+      after
+        @timeout -> {:error, :timeout}
+      end
+    end
+  end
+
+  @impl GenServer
+  @spec init(keyword) :: {:ok, map}
+  def init(_opts) do
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_call({:create, name, pid, opts}, _from, state) do
+    # Set the server as the heir
+    opts = opts ++ [{:heir, self(), nil}]
+
+    # This process can't afford to die, so we capture unexpected ets errors
+    try do
+      {:reply, :ok, create_or_give(name, pid, opts, state)}
+    rescue
+      ArgumentError -> {:reply, {:error, :ets_error}, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_info({:"ETS-TRANSFER", table, _pid, _data}, state) do
+    {:noreply, Map.put(state, table, nil)}
+  end
+
+  defp create_or_give(name, pid, opts, state) do
+    if not Map.has_key?(state, name) do
+      # Attempt to create the table
+      # All tables created here are named for simplicity
+      :ets.new(name, opts ++ [:named_table])
+    end
+
+    :ets.give_away(name, pid, nil)
+    Map.put(state, name, pid)
+  end
+end

--- a/lib/mobius/services/ets_shelf.ex
+++ b/lib/mobius/services/ets_shelf.ex
@@ -12,7 +12,7 @@ defmodule Mobius.Services.ETSShelf do
 
   @spec create_table(atom, [atom | tuple]) :: :ok | {:error, :ets_error}
   def create_table(name, opts) when is_atom(name) do
-    # Creates the table or gives it back if the server already owns it
+    # Creates the table or gives it back if the shelf already owns it
     with :ok <- GenServer.call(__MODULE__, {:create, name, self(), opts}) do
       receive do
         {:"ETS-TRANSFER", ^name, _pid, _data} -> :ok
@@ -30,7 +30,7 @@ defmodule Mobius.Services.ETSShelf do
 
   @impl GenServer
   def handle_call({:create, name, pid, opts}, _from, state) do
-    # Set the server as the heir
+    # Set the shelf as the heir
     opts = opts ++ [{:heir, self(), nil}]
 
     # This process can't afford to die, so we capture unexpected ets errors

--- a/test/mobius/core/shard_list_test.exs
+++ b/test/mobius/core/shard_list_test.exs
@@ -1,0 +1,37 @@
+defmodule Mobius.Core.ShardListTest do
+  use ExUnit.Case
+
+  alias Mobius.Core.ShardInfo
+  alias Mobius.Core.ShardList
+
+  setup do
+    tab = :ets.new(:shard_list, ShardList.table_options())
+    shards = ShardInfo.from_count(2)
+    Enum.each(shards, &ShardList.add_shard(tab, &1))
+    [table: tab, shards: shards]
+  end
+
+  describe "list_shards/1" do
+    test "lists all added shards", ctx do
+      assert ctx.shards == ShardList.list_shards(ctx.table)
+    end
+
+    test "includes ready shards", ctx do
+      ShardList.update_shard_ready(ctx.table, List.first(ctx.shards))
+
+      assert ctx.shards == ShardList.list_shards(ctx.table)
+    end
+  end
+
+  describe "are_all_shards_ready?/1" do
+    test "returns false if one or more shards aren't ready", ctx do
+      assert false == ShardList.are_all_shards_ready?(ctx.table)
+    end
+
+    test "returns true if all shards are ready", ctx do
+      Enum.each(ctx.shards, &ShardList.update_shard_ready(ctx.table, &1))
+
+      assert true == ShardList.are_all_shards_ready?(ctx.table)
+    end
+  end
+end

--- a/test/mobius/services/ets_shelf_test.exs
+++ b/test/mobius/services/ets_shelf_test.exs
@@ -1,0 +1,38 @@
+defmodule Mobius.Services.ETSShelfTest do
+  use ExUnit.Case
+
+  import Mobius.Fixtures
+
+  alias Mobius.Services.ETSShelf, as: Shelf
+
+  setup do
+    [table: :"test_table_#{random_hex(8)}"]
+  end
+
+  test "create_table/2 returns {:error, :ets_error} if table already exists", ctx do
+    table = :ets.new(ctx.table, [:named_table])
+    assert {:error, :ets_error} == Shelf.create_table(table, [])
+  end
+
+  test "create_table/2", ctx do
+    pid = self()
+
+    task =
+      Task.async(fn ->
+        Shelf.create_table(ctx.table, [])
+        send(pid, :ready)
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive :ready
+
+    # Table is owned by the task
+    assert {:error, :ets_error} == Shelf.create_table(ctx.table, [])
+    Task.shutdown(task)
+
+    # Table went back to the shelf
+    assert :ok == Shelf.create_table(ctx.table, [])
+
+    assert :ets.insert(ctx.table, {123, :my_thing})
+  end
+end

--- a/test/mobius/services/ets_shelf_test.exs
+++ b/test/mobius/services/ets_shelf_test.exs
@@ -9,30 +9,32 @@ defmodule Mobius.Services.ETSShelfTest do
     [table: :"test_table_#{random_hex(8)}"]
   end
 
-  test "create_table/2 returns {:error, :ets_error} if table already exists", ctx do
-    table = :ets.new(ctx.table, [:named_table])
-    assert {:error, :ets_error} == Shelf.create_table(table, [])
-  end
+  describe "create_table/2" do
+    test "returns {:error, :ets_error} if table already exists", ctx do
+      table = :ets.new(ctx.table, [:named_table])
+      assert {:error, :ets_error} == Shelf.create_table(table, [])
+    end
 
-  test "create_table/2 gives the table after original owner dies", ctx do
-    pid = self()
+    test "gives the table after original owner dies", ctx do
+      pid = self()
 
-    task =
-      Task.async(fn ->
-        Shelf.create_table(ctx.table, [])
-        send(pid, :ready)
-        Process.sleep(:infinity)
-      end)
+      task =
+        Task.async(fn ->
+          Shelf.create_table(ctx.table, [])
+          send(pid, :ready)
+          Process.sleep(:infinity)
+        end)
 
-    assert_receive :ready
+      assert_receive :ready
 
-    # Table is owned by the task
-    assert {:error, :ets_error} == Shelf.create_table(ctx.table, [])
-    Task.shutdown(task)
+      # Table is owned by the task
+      assert {:error, :ets_error} == Shelf.create_table(ctx.table, [])
+      Task.shutdown(task)
 
-    # Table went back to the shelf
-    assert :ok == Shelf.create_table(ctx.table, [])
+      # Table went back to the shelf
+      assert :ok == Shelf.create_table(ctx.table, [])
 
-    assert :ets.insert(ctx.table, {123, :my_thing})
+      assert :ets.insert(ctx.table, {123, :my_thing})
+    end
   end
 end

--- a/test/mobius/services/ets_shelf_test.exs
+++ b/test/mobius/services/ets_shelf_test.exs
@@ -14,7 +14,7 @@ defmodule Mobius.Services.ETSShelfTest do
     assert {:error, :ets_error} == Shelf.create_table(table, [])
   end
 
-  test "create_table/2", ctx do
+  test "create_table/2 gives the table after original owner dies", ctx do
     pid = self()
 
     task =


### PR DESCRIPTION
The ETSShelf's only purpose is holding onto ets tables when their owner dies. This prevents data loss when processes which originally held on the table are restarted

This removes a bottleneck from the Bot service just for listing shards and will help keep some features concurrent (ie.: sending a message to a service on all shards won't need to go through the Bot first)