### PR TITLE
feat: Discord event subscription POC

### DIFF
--- a/lib/mobius/actions/events.ex
+++ b/lib/mobius/actions/events.ex
@@ -3,6 +3,7 @@ defmodule Mobius.Actions.Events do
   Functions related to events
   """
 
+  alias Mobius.Core.Event
   alias Mobius.Services.EventPipeline
 
   @doc """
@@ -18,7 +19,7 @@ defmodule Mobius.Actions.Events do
   The caller process is then sent events whose name is in the set
   as messages in the format `{event_name, event_data}`
   where `event_name` is the name of the event as an UPPER_CASE atom
-  such as `:CHANNEL_CREATE` and where `event_data` is a struct
+  such as `:CHANNEL_CREATE` and `event_data` is a struct
   containing all the information given by the event
 
   If the set is not empty,
@@ -27,11 +28,11 @@ defmodule Mobius.Actions.Events do
   See https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events
   for a list of events and their associated data
   """
-  @spec subscribe([atom]) :: :ok
+  @spec subscribe([Event.names()]) :: :ok
   def subscribe(events \\ []) do
     # TODO: Validate event names
     # TODO: Validate intents
-    EventPipeline.subscribe_event_categories(events)
+    EventPipeline.subscribe(events)
   end
 
   @doc """

--- a/lib/mobius/actions/events.ex
+++ b/lib/mobius/actions/events.ex
@@ -5,13 +5,41 @@ defmodule Mobius.Actions.Events do
 
   alias Mobius.Services.EventPipeline
 
+  @doc """
+  Subscribes the calling process to a set of (or all) events
+
+  Subscribing multiple times with overlapping events will result
+  in duplicate events. As such, it is discouraged to subscribe
+  multiple times from the same process since this may cause
+  performance degradation
+
+  If an empty list (the default) is given, subscribes to all events
+
+  The caller process is then sent events whose name is in the set
+  as messages in the format `{event_name, event_data}`
+  where `event_name` is the name of the event as an UPPER_CASE atom
+  such as `:CHANNEL_CREATE` and where `event_data` is a struct
+  containing all the information given by the event
+
+  If the set is not empty,
+  the event will be sent if `Enum.member?(events, event_name)` is true
+
+  See https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events
+  for a list of events and their associated data
+  """
   @spec subscribe([atom]) :: :ok
-  def subscribe(events) do
+  def subscribe(events \\ []) do
     # TODO: Validate event names
     # TODO: Validate intents
     EventPipeline.subscribe_event_categories(events)
   end
 
+  @doc """
+  Unsubscribes the calling process from all events it was subscribed to
+
+  If the calling process had `subscribe/1`d multiple times,
+  this unsubscribes from all of them
+  """
   @spec unsubscribe() :: :ok
   def unsubscribe do
     EventPipeline.unsubscribe()

--- a/lib/mobius/actions/events.ex
+++ b/lib/mobius/actions/events.ex
@@ -5,6 +5,8 @@ defmodule Mobius.Actions.Events do
 
   alias Mobius.Core.Event
   alias Mobius.Services.EventPipeline
+  alias Mobius.Validations.EventValidator
+  alias Mobius.Validations.Utils
 
   @doc """
   Subscribes the calling process to a set of (or all) events
@@ -28,11 +30,12 @@ defmodule Mobius.Actions.Events do
   See https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events
   for a list of events and their associated data
   """
-  @spec subscribe([Event.names()]) :: :ok
+  @spec subscribe([Event.names()]) :: Utils.output()
   def subscribe(events \\ []) do
-    # TODO: Validate event names
-    # TODO: Validate intents
-    EventPipeline.subscribe(events)
+    with :ok <- EventValidator.validate_names(events) do
+      # TODO: Validate intents
+      EventPipeline.subscribe(events)
+    end
   end
 
   @doc """

--- a/lib/mobius/actions/events.ex
+++ b/lib/mobius/actions/events.ex
@@ -3,13 +3,14 @@ defmodule Mobius.Actions.Events do
   Functions related to events
   """
 
-  alias Mobius.Core.Event
   alias Mobius.Services.EventPipeline
   alias Mobius.Validations.EventValidator
   alias Mobius.Validations.Utils
 
   @doc """
   Subscribes the calling process to a set of (or all) events
+
+  Passing invalid event names will cause this function to return `{:errors, [String.t()]}`
 
   Subscribing multiple times with overlapping events will result
   in duplicate events. As such, it is discouraged to subscribe
@@ -30,7 +31,7 @@ defmodule Mobius.Actions.Events do
   See https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events
   for a list of events and their associated data
   """
-  @spec subscribe([Event.name()]) :: Utils.output()
+  @spec subscribe([any]) :: Utils.output()
   def subscribe(events \\ []) do
     with :ok <- EventValidator.validate_names(events) do
       # TODO: Validate intents

--- a/lib/mobius/actions/events.ex
+++ b/lib/mobius/actions/events.ex
@@ -30,7 +30,7 @@ defmodule Mobius.Actions.Events do
   See https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events
   for a list of events and their associated data
   """
-  @spec subscribe([Event.names()]) :: Utils.output()
+  @spec subscribe([Event.name()]) :: Utils.output()
   def subscribe(events \\ []) do
     with :ok <- EventValidator.validate_names(events) do
       # TODO: Validate intents
@@ -41,7 +41,7 @@ defmodule Mobius.Actions.Events do
   @doc """
   Unsubscribes the calling process from all events it was subscribed to
 
-  If the calling process had `subscribe/1`d multiple times,
+  If the calling process had called `subscribe/1` multiple times,
   this unsubscribes from all of them
   """
   @spec unsubscribe() :: :ok

--- a/lib/mobius/actions/events.ex
+++ b/lib/mobius/actions/events.ex
@@ -1,0 +1,19 @@
+defmodule Mobius.Actions.Events do
+  @moduledoc """
+  Functions related to events
+  """
+
+  alias Mobius.Services.EventPipeline
+
+  @spec subscribe([atom]) :: :ok
+  def subscribe(events) do
+    # TODO: Validate event names
+    # TODO: Validate intents
+    EventPipeline.subscribe_event_categories(events)
+  end
+
+  @spec unsubscribe() :: :ok
+  def unsubscribe do
+    EventPipeline.unsubscribe()
+  end
+end

--- a/lib/mobius/application.ex
+++ b/lib/mobius/application.ex
@@ -16,6 +16,7 @@ defmodule Mobius.Application do
       dynamic_supervisor(Mobius.Supervisor.Shard),
       dynamic_supervisor(Mobius.Supervisor.Socket),
       {Mobius.Services.PubSub, []},
+      {Mobius.Services.EventPipeline, []},
       {Mobius.Services.Bot, token: System.get_env("MOBIUS_BOT_TOKEN")}
     ]
 

--- a/lib/mobius/core/event.ex
+++ b/lib/mobius/core/event.ex
@@ -2,40 +2,41 @@ defmodule Mobius.Core.Event do
   @moduledoc false
 
   @valid_names [
-    "CHANNEL_CREATE",
-    "CHANNEL_UPDATE",
-    "CHANNEL_DELETE",
-    "CHANNEL_PINS_UPDATE",
-    "GUILD_CREATE",
-    "GUILD_UPDATE",
-    "GUILD_DELETE",
-    "GUILD_BAN_ADD",
-    "GUILD_BAN_REMOVE",
-    "GUILD_EMOJIS_UPDATE",
-    "GUILD_INTEGRATIONS_UPDATE",
-    "GUILD_MEMBER_ADD",
-    "GUILD_MEMBER_REMOVE",
-    "GUILD_MEMBER_UPDATE",
-    "GUILD_ROLE_CREATE",
-    "GUILD_ROLE_UPDATE",
-    "GUILD_ROLE_DELETE",
-    "INVITE_CREATE",
-    "INVITE_DELETE",
-    "MESSAGE_CREATE",
-    "MESSAGE_UPDATE",
-    "MESSAGE_DELETE",
-    "MESSAGE_DELETE_BULK",
-    "MESSAGE_REACTION_ADD",
-    "MESSAGE_REACTION_REMOVE",
-    "MESSAGE_REACTION_REMOVE_ALL",
-    "MESSAGE_REACTION_REMOVE_EMOJI",
-    "PRESENCE_UPDATE",
-    "TYPING_START",
-    "USER_UPDATE",
-    "VOICE_STATE_UPDATE",
-    "VOICE_SERVER_UPDATE",
-    "WEBHOOKS_UPDATE"
+    :CHANNEL_CREATE,
+    :CHANNEL_UPDATE,
+    :CHANNEL_DELETE,
+    :CHANNEL_PINS_UPDATE,
+    :GUILD_CREATE,
+    :GUILD_UPDATE,
+    :GUILD_DELETE,
+    :GUILD_BAN_ADD,
+    :GUILD_BAN_REMOVE,
+    :GUILD_EMOJIS_UPDATE,
+    :GUILD_INTEGRATIONS_UPDATE,
+    :GUILD_MEMBER_ADD,
+    :GUILD_MEMBER_REMOVE,
+    :GUILD_MEMBER_UPDATE,
+    :GUILD_ROLE_CREATE,
+    :GUILD_ROLE_UPDATE,
+    :GUILD_ROLE_DELETE,
+    :INVITE_CREATE,
+    :INVITE_DELETE,
+    :MESSAGE_CREATE,
+    :MESSAGE_UPDATE,
+    :MESSAGE_DELETE,
+    :MESSAGE_DELETE_BULK,
+    :MESSAGE_REACTION_ADD,
+    :MESSAGE_REACTION_REMOVE,
+    :MESSAGE_REACTION_REMOVE_ALL,
+    :MESSAGE_REACTION_REMOVE_EMOJI,
+    :PRESENCE_UPDATE,
+    :TYPING_START,
+    :USER_UPDATE,
+    :VOICE_STATE_UPDATE,
+    :VOICE_SERVER_UPDATE,
+    :WEBHOOKS_UPDATE
   ]
+  @valid_string_names Enum.map(@valid_names, &Atom.to_string/1)
 
   @type names ::
           :CHANNEL_CREATE
@@ -74,8 +75,12 @@ defmodule Mobius.Core.Event do
 
   @doc "Converts string event names to atoms if it's valid otherwise returns nil"
   @spec parse_name(String.t()) :: names() | nil
-  def parse_name(name) when name in @valid_names, do: String.to_atom(name)
+  def parse_name(name) when name in @valid_string_names, do: String.to_existing_atom(name)
   def parse_name(_name), do: nil
+
+  @doc "Returns true if the given name is a valid event name"
+  @spec is_valid_name?(atom) :: boolean
+  def is_valid_name?(name), do: name in @valid_names
 
   @spec parse_data(names(), any) :: any
   def parse_data(_name, data), do: data

--- a/lib/mobius/core/event.ex
+++ b/lib/mobius/core/event.ex
@@ -39,7 +39,7 @@ defmodule Mobius.Core.Event do
   ]
   @valid_string_names Enum.map(@valid_names, &Atom.to_string/1)
 
-  @type names ::
+  @type name ::
           :READY
           | :CHANNEL_CREATE
           | :CHANNEL_UPDATE
@@ -75,8 +75,8 @@ defmodule Mobius.Core.Event do
           | :VOICE_SERVER_UPDATE
           | :WEBHOOKS_UPDATE
 
-  @doc "Converts string event names to atoms if it's valid otherwise returns nil"
-  @spec parse_name(String.t()) :: names() | nil
+  @doc "Converts string event names to atoms if it's valid. Returns `nil` otherwise."
+  @spec parse_name(String.t()) :: name() | nil
   def parse_name(name) when name in @valid_string_names, do: String.to_existing_atom(name)
   def parse_name(_name), do: nil
 
@@ -84,6 +84,15 @@ defmodule Mobius.Core.Event do
   @spec is_event_name?(atom) :: boolean
   def is_event_name?(name), do: name in @valid_names
 
-  @spec parse_data(names(), any) :: any
+  @doc """
+  Parses the given data based on the event name
+
+  This function is only implemented for valid event names (see `t:name/0` and `is_event_name?/1`)
+  such that passing an invalid event name will raise an error to the caller
+
+  If you are calling this function with potentially invalid event names,
+  use `is_event_name?/1` to first make sure the event name is valid
+  """
+  @spec parse_data(name(), any) :: any
   def parse_data(name, data) when name in @valid_names, do: data
 end

--- a/lib/mobius/core/event.ex
+++ b/lib/mobius/core/event.ex
@@ -79,8 +79,8 @@ defmodule Mobius.Core.Event do
   def parse_name(_name), do: nil
 
   @doc "Returns true if the given name is a valid event name"
-  @spec is_valid_name?(atom) :: boolean
-  def is_valid_name?(name), do: name in @valid_names
+  @spec is_event_name?(atom) :: boolean
+  def is_event_name?(name), do: name in @valid_names
 
   @spec parse_data(names(), any) :: any
   def parse_data(_name, data), do: data

--- a/lib/mobius/core/event.ex
+++ b/lib/mobius/core/event.ex
@@ -2,82 +2,85 @@ defmodule Mobius.Core.Event do
   @moduledoc false
 
   @valid_names [
-    :READY,
-    :CHANNEL_CREATE,
-    :CHANNEL_UPDATE,
-    :CHANNEL_DELETE,
-    :CHANNEL_PINS_UPDATE,
-    :GUILD_CREATE,
-    :GUILD_UPDATE,
-    :GUILD_DELETE,
-    :GUILD_BAN_ADD,
-    :GUILD_BAN_REMOVE,
-    :GUILD_EMOJIS_UPDATE,
-    :GUILD_INTEGRATIONS_UPDATE,
-    :GUILD_MEMBER_ADD,
-    :GUILD_MEMBER_REMOVE,
-    :GUILD_MEMBER_UPDATE,
-    :GUILD_ROLE_CREATE,
-    :GUILD_ROLE_UPDATE,
-    :GUILD_ROLE_DELETE,
-    :INVITE_CREATE,
-    :INVITE_DELETE,
-    :MESSAGE_CREATE,
-    :MESSAGE_UPDATE,
-    :MESSAGE_DELETE,
-    :MESSAGE_DELETE_BULK,
-    :MESSAGE_REACTION_ADD,
-    :MESSAGE_REACTION_REMOVE,
-    :MESSAGE_REACTION_REMOVE_ALL,
-    :MESSAGE_REACTION_REMOVE_EMOJI,
-    :PRESENCE_UPDATE,
-    :TYPING_START,
-    :USER_UPDATE,
-    :VOICE_STATE_UPDATE,
-    :VOICE_SERVER_UPDATE,
-    :WEBHOOKS_UPDATE
+    :ready,
+    :channel_create,
+    :channel_update,
+    :channel_delete,
+    :channel_pins_update,
+    :guild_create,
+    :guild_update,
+    :guild_delete,
+    :guild_ban_add,
+    :guild_ban_remove,
+    :guild_emojis_update,
+    :guild_integrations_update,
+    :guild_member_add,
+    :guild_member_remove,
+    :guild_member_update,
+    :guild_role_create,
+    :guild_role_update,
+    :guild_role_delete,
+    :invite_create,
+    :invite_delete,
+    :message_create,
+    :message_update,
+    :message_delete,
+    :message_delete_bulk,
+    :message_reaction_add,
+    :message_reaction_remove,
+    :message_reaction_remove_all,
+    :message_reaction_remove_emoji,
+    :presence_update,
+    :typing_start,
+    :user_update,
+    :voice_state_update,
+    :voice_server_update,
+    :webhooks_update
   ]
-  @valid_string_names Enum.map(@valid_names, &Atom.to_string/1)
+  @valid_string_names Enum.map(@valid_names, &String.upcase(Atom.to_string(&1)))
 
   @type name ::
-          :READY
-          | :CHANNEL_CREATE
-          | :CHANNEL_UPDATE
-          | :CHANNEL_DELETE
-          | :CHANNEL_PINS_UPDATE
-          | :GUILD_CREATE
-          | :GUILD_UPDATE
-          | :GUILD_DELETE
-          | :GUILD_BAN_ADD
-          | :GUILD_BAN_REMOVE
-          | :GUILD_EMOJIS_UPDATE
-          | :GUILD_INTEGRATIONS_UPDATE
-          | :GUILD_MEMBER_ADD
-          | :GUILD_MEMBER_REMOVE
-          | :GUILD_MEMBER_UPDATE
-          | :GUILD_ROLE_CREATE
-          | :GUILD_ROLE_UPDATE
-          | :GUILD_ROLE_DELETE
-          | :INVITE_CREATE
-          | :INVITE_DELETE
-          | :MESSAGE_CREATE
-          | :MESSAGE_UPDATE
-          | :MESSAGE_DELETE
-          | :MESSAGE_DELETE_BULK
-          | :MESSAGE_REACTION_ADD
-          | :MESSAGE_REACTION_REMOVE
-          | :MESSAGE_REACTION_REMOVE_ALL
-          | :MESSAGE_REACTION_REMOVE_EMOJI
-          | :PRESENCE_UPDATE
-          | :TYPING_START
-          | :USER_UPDATE
-          | :VOICE_STATE_UPDATE
-          | :VOICE_SERVER_UPDATE
-          | :WEBHOOKS_UPDATE
+          :ready
+          | :channel_create
+          | :channel_update
+          | :channel_delete
+          | :channel_pins_update
+          | :guild_create
+          | :guild_update
+          | :guild_delete
+          | :guild_ban_add
+          | :guild_ban_remove
+          | :guild_emojis_update
+          | :guild_integrations_update
+          | :guild_member_add
+          | :guild_member_remove
+          | :guild_member_update
+          | :guild_role_create
+          | :guild_role_update
+          | :guild_role_delete
+          | :invite_create
+          | :invite_delete
+          | :message_create
+          | :message_update
+          | :message_delete
+          | :message_delete_bulk
+          | :message_reaction_add
+          | :message_reaction_remove
+          | :message_reaction_remove_all
+          | :message_reaction_remove_emoji
+          | :presence_update
+          | :typing_start
+          | :user_update
+          | :voice_state_update
+          | :voice_server_update
+          | :webhooks_update
 
   @doc "Converts string event names to atoms if it's valid. Returns `nil` otherwise."
   @spec parse_name(String.t()) :: name() | nil
-  def parse_name(name) when name in @valid_string_names, do: String.to_existing_atom(name)
+  def parse_name(name) when name in @valid_string_names do
+    String.to_existing_atom(String.downcase(name))
+  end
+
   def parse_name(_name), do: nil
 
   @doc "Returns true if the given name is a valid event name"

--- a/lib/mobius/core/event.ex
+++ b/lib/mobius/core/event.ex
@@ -1,0 +1,82 @@
+defmodule Mobius.Core.Event do
+  @moduledoc false
+
+  @valid_names [
+    "CHANNEL_CREATE",
+    "CHANNEL_UPDATE",
+    "CHANNEL_DELETE",
+    "CHANNEL_PINS_UPDATE",
+    "GUILD_CREATE",
+    "GUILD_UPDATE",
+    "GUILD_DELETE",
+    "GUILD_BAN_ADD",
+    "GUILD_BAN_REMOVE",
+    "GUILD_EMOJIS_UPDATE",
+    "GUILD_INTEGRATIONS_UPDATE",
+    "GUILD_MEMBER_ADD",
+    "GUILD_MEMBER_REMOVE",
+    "GUILD_MEMBER_UPDATE",
+    "GUILD_ROLE_CREATE",
+    "GUILD_ROLE_UPDATE",
+    "GUILD_ROLE_DELETE",
+    "INVITE_CREATE",
+    "INVITE_DELETE",
+    "MESSAGE_CREATE",
+    "MESSAGE_UPDATE",
+    "MESSAGE_DELETE",
+    "MESSAGE_DELETE_BULK",
+    "MESSAGE_REACTION_ADD",
+    "MESSAGE_REACTION_REMOVE",
+    "MESSAGE_REACTION_REMOVE_ALL",
+    "MESSAGE_REACTION_REMOVE_EMOJI",
+    "PRESENCE_UPDATE",
+    "TYPING_START",
+    "USER_UPDATE",
+    "VOICE_STATE_UPDATE",
+    "VOICE_SERVER_UPDATE",
+    "WEBHOOKS_UPDATE"
+  ]
+
+  @type names ::
+          :CHANNEL_CREATE
+          | :CHANNEL_UPDATE
+          | :CHANNEL_DELETE
+          | :CHANNEL_PINS_UPDATE
+          | :GUILD_CREATE
+          | :GUILD_UPDATE
+          | :GUILD_DELETE
+          | :GUILD_BAN_ADD
+          | :GUILD_BAN_REMOVE
+          | :GUILD_EMOJIS_UPDATE
+          | :GUILD_INTEGRATIONS_UPDATE
+          | :GUILD_MEMBER_ADD
+          | :GUILD_MEMBER_REMOVE
+          | :GUILD_MEMBER_UPDATE
+          | :GUILD_ROLE_CREATE
+          | :GUILD_ROLE_UPDATE
+          | :GUILD_ROLE_DELETE
+          | :INVITE_CREATE
+          | :INVITE_DELETE
+          | :MESSAGE_CREATE
+          | :MESSAGE_UPDATE
+          | :MESSAGE_DELETE
+          | :MESSAGE_DELETE_BULK
+          | :MESSAGE_REACTION_ADD
+          | :MESSAGE_REACTION_REMOVE
+          | :MESSAGE_REACTION_REMOVE_ALL
+          | :MESSAGE_REACTION_REMOVE_EMOJI
+          | :PRESENCE_UPDATE
+          | :TYPING_START
+          | :USER_UPDATE
+          | :VOICE_STATE_UPDATE
+          | :VOICE_SERVER_UPDATE
+          | :WEBHOOKS_UPDATE
+
+  @doc "Converts string event names to atoms if it's valid otherwise returns nil"
+  @spec parse_name(String.t()) :: names() | nil
+  def parse_name(name) when name in @valid_names, do: String.to_atom(name)
+  def parse_name(_name), do: nil
+
+  @spec parse_data(names(), any) :: any
+  def parse_data(_name, data), do: data
+end

--- a/lib/mobius/core/event.ex
+++ b/lib/mobius/core/event.ex
@@ -2,6 +2,7 @@ defmodule Mobius.Core.Event do
   @moduledoc false
 
   @valid_names [
+    :READY,
     :CHANNEL_CREATE,
     :CHANNEL_UPDATE,
     :CHANNEL_DELETE,
@@ -39,7 +40,8 @@ defmodule Mobius.Core.Event do
   @valid_string_names Enum.map(@valid_names, &Atom.to_string/1)
 
   @type names ::
-          :CHANNEL_CREATE
+          :READY
+          | :CHANNEL_CREATE
           | :CHANNEL_UPDATE
           | :CHANNEL_DELETE
           | :CHANNEL_PINS_UPDATE
@@ -83,5 +85,5 @@ defmodule Mobius.Core.Event do
   def is_event_name?(name), do: name in @valid_names
 
   @spec parse_data(names(), any) :: any
-  def parse_data(_name, data), do: data
+  def parse_data(name, data) when name in @valid_names, do: data
 end

--- a/lib/mobius/services/bot.ex
+++ b/lib/mobius/services/bot.ex
@@ -7,6 +7,7 @@ defmodule Mobius.Services.Bot do
   alias Mobius.Core.ShardList
   alias Mobius.Rest
   alias Mobius.Services.ETSShelf
+  alias Mobius.Services.EventPipeline
   alias Mobius.Services.Shard
 
   require Logger
@@ -56,6 +57,11 @@ defmodule Mobius.Services.Bot do
   def handle_info({:shard_ready, shard}, state) do
     Logger.debug("Shard #{inspect(shard)} is ready!")
     ShardList.update_shard_ready(@shards_table, shard)
+
+    if ShardList.are_all_shards_ready?(@shards_table) do
+      EventPipeline.notify_event("READY", nil)
+    end
+
     {:noreply, state}
   end
 

--- a/lib/mobius/services/event_pipeline.ex
+++ b/lib/mobius/services/event_pipeline.ex
@@ -1,0 +1,35 @@
+defmodule Mobius.Services.EventPipeline do
+  @moduledoc false
+
+  alias Mobius.Services.PubSub
+
+  @pubsub_topic "events"
+
+  @spec child_spec(keyword) :: Supervisor.child_spec()
+  def child_spec(_opts) do
+    Task.Supervisor.child_spec(name: __MODULE__)
+  end
+
+  @doc "Sends an event to all subscribed processes"
+  @spec notify_event(atom, any) :: :ok
+  def notify_event(name, data) do
+    Task.Supervisor.start_child(__MODULE__, fn ->
+      # TODO: Map data depending on name
+      PubSub.publish(@pubsub_topic, name, data)
+    end)
+
+    :ok
+  end
+
+  @doc "Subscribes the calling process to an arbitrary set of events"
+  @spec subscribe_event_categories([atom]) :: :ok
+  def subscribe_event_categories(events) do
+    PubSub.subscribe(@pubsub_topic, events)
+  end
+
+  @doc "Unsubscribes the calling process from all events"
+  @spec unsubscribe :: :ok
+  def unsubscribe do
+    PubSub.unsubscribe(@pubsub_topic)
+  end
+end

--- a/lib/mobius/services/event_pipeline.ex
+++ b/lib/mobius/services/event_pipeline.ex
@@ -21,6 +21,7 @@ defmodule Mobius.Services.EventPipeline do
     Task.Supervisor.start_child(__MODULE__, fn ->
       parsed_name = Event.parse_name(name)
 
+      # Ignore unrecognized events
       if parsed_name != nil do
         parsed_data = Event.parse_data(parsed_name, data)
         PubSub.publish(@pubsub_topic, parsed_name, parsed_data)

--- a/lib/mobius/services/event_pipeline.ex
+++ b/lib/mobius/services/event_pipeline.ex
@@ -32,7 +32,7 @@ defmodule Mobius.Services.EventPipeline do
   end
 
   @doc "Subscribes the calling process to an arbitrary set of events"
-  @spec subscribe([Event.names()]) :: :ok
+  @spec subscribe([Event.name()]) :: :ok
   def subscribe(events) do
     PubSub.subscribe(@pubsub_topic, events)
   end

--- a/lib/mobius/services/event_pipeline.ex
+++ b/lib/mobius/services/event_pipeline.ex
@@ -13,6 +13,10 @@ defmodule Mobius.Services.EventPipeline do
   @doc "Sends an event to all subscribed processes"
   @spec notify_event(atom, any) :: :ok
   def notify_event(name, data) do
+    # Starting in an unlinked task for 3 reasons:
+    # 1. We don't want the source of the events to spend time mapping events
+    # 2. We want this work to be parallelized
+    # 3. We don't want errors in here to crash the source of events
     Task.Supervisor.start_child(__MODULE__, fn ->
       # TODO: Map data depending on name
       PubSub.publish(@pubsub_topic, name, data)

--- a/lib/mobius/services/event_pipeline.ex
+++ b/lib/mobius/services/event_pipeline.ex
@@ -32,8 +32,8 @@ defmodule Mobius.Services.EventPipeline do
   end
 
   @doc "Subscribes the calling process to an arbitrary set of events"
-  @spec subscribe_event_categories([atom]) :: :ok
-  def subscribe_event_categories(events) do
+  @spec subscribe([Event.names()]) :: :ok
+  def subscribe(events) do
     PubSub.subscribe(@pubsub_topic, events)
   end
 

--- a/lib/mobius/services/shard.ex
+++ b/lib/mobius/services/shard.ex
@@ -184,7 +184,7 @@ defmodule Mobius.Services.Shard do
 
   defp update_state_by_event(state, _payload), do: state
 
-  defp broadcast_event(state, %{t: type}) when type in [:READY], do: state
+  defp broadcast_event(state, %{t: type}) when type in ["READY"], do: state
 
   defp broadcast_event(state, payload) do
     EventPipeline.notify_event(payload.t, payload.d)

--- a/lib/mobius/validations/event_validator.ex
+++ b/lib/mobius/validations/event_validator.ex
@@ -1,0 +1,21 @@
+defmodule Mobius.Validations.EventValidator do
+  @moduledoc false
+
+  alias Mobius.Core.Event
+  alias Mobius.Validations.Utils
+
+  @spec validate_names([any]) :: Utils.out()
+  def validate_names(names) do
+    names
+    |> Utils.check_list(&validate_name/1)
+    |> Utils.errors_to_output()
+  end
+
+  defp validate_name(name) do
+    if Event.is_event_name?(name) do
+      :ok
+    else
+      {:error, "invalid event name: #{inspect(name)}"}
+    end
+  end
+end

--- a/test/mobius/actions/events_test.exs
+++ b/test/mobius/actions/events_test.exs
@@ -12,33 +12,33 @@ defmodule Mobius.Actions.EventsTest do
 
   describe "subscribe/1" do
     test "returns {:errors, [String]} if any event is invalid" do
-      assert {:errors, errors} = Events.subscribe([:THIS_ISNT_AN_EVENT])
-      assert ["invalid event name: :THIS_ISNT_AN_EVENT"] = errors
+      assert {:errors, errors} = Events.subscribe([:this_isnt_an_event])
+      assert ["invalid event name: :this_isnt_an_event"] = errors
     end
 
     test "returns :ok if all event names are valid" do
-      assert :ok == Events.subscribe([:GUILD_BAN_ADD, :INVITE_CREATE, :USER_UPDATE])
+      assert :ok == Events.subscribe([:guild_ban_add, :invite_create, :user_update])
     end
 
     test "sends subscribed event to caller as a message" do
-      Events.subscribe([:CHANNEL_CREATE, :WEBHOOKS_UPDATE, :CHANNEL_DELETE])
+      Events.subscribe([:channel_create, :webhooks_update, :channel_delete])
       send_payload(op: :dispatch, type: "WEBHOOKS_UPDATE")
 
-      assert_receive {:WEBHOOKS_UPDATE, _}
+      assert_receive {:webhooks_update, _}
     end
 
     test "doesn't send event if not subscribed" do
-      Events.subscribe([:MESSAGE_UPDATE, :MESSAGE_DELETE])
+      Events.subscribe([:message_update, :message_delete])
       send_payload(op: :dispatch, type: "MESSAGE_CREATE")
 
-      refute_receive {:MESSAGE_CREATE, _}
+      refute_receive {:message_create, _}
     end
 
     test "sends all events if subscribing to empty list" do
       Events.subscribe([])
       send_payload(op: :dispatch, type: "TYPING_START")
 
-      assert_receive {:TYPING_START, _}
+      assert_receive {:typing_start, _}
     end
   end
 
@@ -58,12 +58,12 @@ defmodule Mobius.Actions.EventsTest do
       send_payload(op: :dispatch, type: "TYPING_START")
 
       # Confirm we do receive events
-      assert_receive {:TYPING_START, _}
+      assert_receive {:typing_start, _}
 
       Events.unsubscribe()
 
       send_payload(op: :dispatch, type: "MESSAGE_REACTION_ADD")
-      refute_receive {:MESSAGE_REACTION_ADD, _}
+      refute_receive {:message_reaction_add, _}
     end
   end
 end

--- a/test/mobius/actions/events_test.exs
+++ b/test/mobius/actions/events_test.exs
@@ -1,0 +1,69 @@
+defmodule Mobius.Actions.EventsTest do
+  use ExUnit.Case
+
+  import Mobius.Fixtures
+
+  alias Mobius.Actions.Events
+
+  setup :get_shard
+  setup :reset_services
+  setup :stub_socket
+  setup :handshake_shard
+
+  describe "subscribe/1" do
+    test "returns {:errors, [String]} if any event is invalid" do
+      assert {:errors, errors} = Events.subscribe([:THIS_ISNT_AN_EVENT])
+      assert ["invalid event name: :THIS_ISNT_AN_EVENT"] = errors
+    end
+
+    test "returns :ok if all event names are valid" do
+      assert :ok == Events.subscribe([:GUILD_BAN_ADD, :INVITE_CREATE, :USER_UPDATE])
+    end
+
+    test "sends subscribed event to caller as a message" do
+      Events.subscribe([:CHANNEL_CREATE, :WEBHOOKS_UPDATE, :CHANNEL_DELETE])
+      send_payload(op: :dispatch, type: "WEBHOOKS_UPDATE")
+
+      assert_receive {:WEBHOOKS_UPDATE, _}
+    end
+
+    test "doesn't send event if not subscribed" do
+      Events.subscribe([:MESSAGE_UPDATE, :MESSAGE_DELETE])
+      send_payload(op: :dispatch, type: "MESSAGE_CREATE")
+
+      refute_receive {:MESSAGE_CREATE, _}
+    end
+
+    test "sends all events if subscribing to empty list" do
+      Events.subscribe([])
+      send_payload(op: :dispatch, type: "TYPING_START")
+
+      assert_receive {:TYPING_START, _}
+    end
+  end
+
+  describe "unsubscribe/0" do
+    test "returns :ok even if not subscribed" do
+      assert :ok == Events.unsubscribe()
+    end
+
+    test "returns :ok when subscribed" do
+      Events.subscribe()
+
+      assert :ok == Events.unsubscribe()
+    end
+
+    test "stops sending events after unsubscribing" do
+      Events.subscribe()
+      send_payload(op: :dispatch, type: "TYPING_START")
+
+      # Confirm we do receive events
+      assert_receive {:TYPING_START, _}
+
+      Events.unsubscribe()
+
+      send_payload(op: :dispatch, type: "MESSAGE_REACTION_ADD")
+      refute_receive {:MESSAGE_REACTION_ADD, _}
+    end
+  end
+end

--- a/test/mobius/core/event_test.exs
+++ b/test/mobius/core/event_test.exs
@@ -42,6 +42,10 @@ defmodule Mobius.Core.EventTest do
   end
 
   describe "parse_data/2" do
+    test "raises a FunctionClauseError if the event name is invalid" do
+      assert_raise FunctionClauseError, fn -> Event.parse_data(:THIS_IS_NOT_AN_EVENT, nil) end
+    end
+
     test "returns data unchanged" do
       random = random_hex(16)
       assert random == Event.parse_data(:READY, random)

--- a/test/mobius/core/event_test.exs
+++ b/test/mobius/core/event_test.exs
@@ -1,0 +1,50 @@
+defmodule Mobius.Core.EventTest do
+  use ExUnit.Case
+
+  import Mobius.Fixtures
+
+  alias Mobius.Core.Event
+
+  describe "parse_name/1" do
+    test "returns atom event name for string event name" do
+      assert :GUILD_CREATE == Event.parse_name("GUILD_CREATE")
+    end
+
+    test "returns nil for event name atoms" do
+      assert nil == Event.parse_name(:CHANNEL_CREATE)
+    end
+
+    test "returns nil for non-event string" do
+      assert nil == Event.parse_name("THIS IS NOT AN EVENT")
+    end
+
+    test "returns nil for number" do
+      assert nil == Event.parse_name(42)
+    end
+  end
+
+  describe "is_event_name?/1" do
+    test "returns true for a valid event name" do
+      assert Event.is_event_name?(:MESSAGE_CREATE)
+    end
+
+    test "returns false for the string of an event name" do
+      assert not Event.is_event_name?("MESSAGE_CREATE")
+    end
+
+    test "returns false for non-atoms" do
+      assert not Event.is_event_name?(32)
+    end
+
+    test "returns false for invalid event name atom" do
+      assert not Event.is_event_name?(:THIS_IS_NOT_AN_EVENT)
+    end
+  end
+
+  describe "parse_data/2" do
+    test "returns data unchanged" do
+      random = random_hex(16)
+      assert random == Event.parse_data(:READY, random)
+    end
+  end
+end

--- a/test/mobius/core/event_test.exs
+++ b/test/mobius/core/event_test.exs
@@ -7,11 +7,11 @@ defmodule Mobius.Core.EventTest do
 
   describe "parse_name/1" do
     test "returns atom event name for string event name" do
-      assert :GUILD_CREATE == Event.parse_name("GUILD_CREATE")
+      assert :guild_create == Event.parse_name("GUILD_CREATE")
     end
 
     test "returns nil for event name atoms" do
-      assert nil == Event.parse_name(:CHANNEL_CREATE)
+      assert nil == Event.parse_name(:channel_create)
     end
 
     test "returns nil for non-event string" do
@@ -25,7 +25,7 @@ defmodule Mobius.Core.EventTest do
 
   describe "is_event_name?/1" do
     test "returns true for a valid event name" do
-      assert Event.is_event_name?(:MESSAGE_CREATE)
+      assert Event.is_event_name?(:message_create)
     end
 
     test "returns false for the string of an event name" do
@@ -37,18 +37,18 @@ defmodule Mobius.Core.EventTest do
     end
 
     test "returns false for invalid event name atom" do
-      assert not Event.is_event_name?(:THIS_IS_NOT_AN_EVENT)
+      assert not Event.is_event_name?(:this_isnt_an_event)
     end
   end
 
   describe "parse_data/2" do
     test "raises a FunctionClauseError if the event name is invalid" do
-      assert_raise FunctionClauseError, fn -> Event.parse_data(:THIS_IS_NOT_AN_EVENT, nil) end
+      assert_raise FunctionClauseError, fn -> Event.parse_data(:this_isnt_an_event, nil) end
     end
 
     test "returns data unchanged" do
       random = random_hex(16)
-      assert random == Event.parse_data(:READY, random)
+      assert random == Event.parse_data(:ready, random)
     end
   end
 end

--- a/test/mobius/core/event_test.exs
+++ b/test/mobius/core/event_test.exs
@@ -10,16 +10,17 @@ defmodule Mobius.Core.EventTest do
       assert :guild_create == Event.parse_name("GUILD_CREATE")
     end
 
-    test "returns nil for event name atoms" do
-      assert nil == Event.parse_name(:channel_create)
-    end
-
     test "returns nil for non-event string" do
       assert nil == Event.parse_name("THIS IS NOT AN EVENT")
     end
 
-    test "returns nil for number" do
+    test "returns nil for non-strings" do
+      assert nil == Event.parse_name(true)
       assert nil == Event.parse_name(42)
+      assert nil == Event.parse_name(:channel_create)
+      assert nil == Event.parse_name(%{})
+      assert nil == Event.parse_name(["stuff"])
+      assert nil == Event.parse_name({:ok, "hello"})
     end
   end
 
@@ -28,12 +29,13 @@ defmodule Mobius.Core.EventTest do
       assert Event.is_event_name?(:message_create)
     end
 
-    test "returns false for the string of an event name" do
-      assert not Event.is_event_name?("MESSAGE_CREATE")
-    end
-
     test "returns false for non-atoms" do
+      assert not Event.is_event_name?(true)
       assert not Event.is_event_name?(32)
+      assert not Event.is_event_name?("MESSAGE_CREATE")
+      assert not Event.is_event_name?(%{})
+      assert not Event.is_event_name?(["stuff"])
+      assert not Event.is_event_name?({:ok, "hello"})
     end
 
     test "returns false for invalid event name atom" do

--- a/test/mobius/services/event_pipeline_test.exs
+++ b/test/mobius/services/event_pipeline_test.exs
@@ -1,0 +1,50 @@
+defmodule Mobius.Services.EventPipelineTest do
+  use ExUnit.Case
+
+  import Mobius.Fixtures
+
+  alias Mobius.Services.EventPipeline
+
+  setup :get_shard
+  setup :reset_services
+  setup :stub_socket
+  setup :handshake_shard
+
+  describe "subscribe/1" do
+    test "sends subscribed event to caller as a message" do
+      EventPipeline.subscribe([:CHANNEL_CREATE, :WEBHOOKS_UPDATE, :CHANNEL_DELETE])
+      send_payload(op: :dispatch, type: "WEBHOOKS_UPDATE")
+
+      assert_receive {:WEBHOOKS_UPDATE, _}
+    end
+
+    test "doesn't send event if not subscribed" do
+      EventPipeline.subscribe([:MESSAGE_UPDATE, :MESSAGE_DELETE])
+      send_payload(op: :dispatch, type: "MESSAGE_CREATE")
+
+      refute_receive {:MESSAGE_CREATE, _}
+    end
+
+    test "sends all events if subscribing to empty list" do
+      EventPipeline.subscribe([])
+      send_payload(op: :dispatch, type: "TYPING_START")
+
+      assert_receive {:TYPING_START, _}
+    end
+  end
+
+  describe "unsubscribe/0" do
+    test "stops sending events after unsubscribing" do
+      EventPipeline.subscribe([])
+      send_payload(op: :dispatch, type: "TYPING_START")
+
+      # Confirm we do receive events
+      assert_receive {:TYPING_START, _}
+
+      EventPipeline.unsubscribe()
+
+      send_payload(op: :dispatch, type: "MESSAGE_REACTION_ADD")
+      refute_receive {:MESSAGE_REACTION_ADD, _}
+    end
+  end
+end

--- a/test/mobius/services/event_pipeline_test.exs
+++ b/test/mobius/services/event_pipeline_test.exs
@@ -12,24 +12,24 @@ defmodule Mobius.Services.EventPipelineTest do
 
   describe "subscribe/1" do
     test "sends subscribed event to caller as a message" do
-      EventPipeline.subscribe([:CHANNEL_CREATE, :WEBHOOKS_UPDATE, :CHANNEL_DELETE])
+      EventPipeline.subscribe([:channel_create, :webhooks_update, :channel_delete])
       send_payload(op: :dispatch, type: "WEBHOOKS_UPDATE")
 
-      assert_receive {:WEBHOOKS_UPDATE, _}
+      assert_receive {:webhooks_update, _}
     end
 
     test "doesn't send event if not subscribed" do
-      EventPipeline.subscribe([:MESSAGE_UPDATE, :MESSAGE_DELETE])
+      EventPipeline.subscribe([:message_update, :message_delete])
       send_payload(op: :dispatch, type: "MESSAGE_CREATE")
 
-      refute_receive {:MESSAGE_CREATE, _}
+      refute_receive {:message_create, _}
     end
 
     test "sends all events if subscribing to empty list" do
       EventPipeline.subscribe([])
       send_payload(op: :dispatch, type: "TYPING_START")
 
-      assert_receive {:TYPING_START, _}
+      assert_receive {:typing_start, _}
     end
   end
 
@@ -39,12 +39,12 @@ defmodule Mobius.Services.EventPipelineTest do
       send_payload(op: :dispatch, type: "TYPING_START")
 
       # Confirm we do receive events
-      assert_receive {:TYPING_START, _}
+      assert_receive {:typing_start, _}
 
       EventPipeline.unsubscribe()
 
       send_payload(op: :dispatch, type: "MESSAGE_REACTION_ADD")
-      refute_receive {:MESSAGE_REACTION_ADD, _}
+      refute_receive {:message_reaction_add, _}
     end
   end
 end


### PR DESCRIPTION
Currently is a POC of how the data flow of events will work

TODO:
- [x] Call a Core module which does the mapping (can be identity for now)
- [x] Add event name validation
- [x] Write documentation in `Mobius.Actions.Events`
- [x] Send `READY` from `Mobius.Services.Bot` when all shards are ready
- [x] Write tests for `Mobius.Core.Event`
- [x] Write tests for `Mobius.Actions.Events`
- [x] Write tests for `Mobius.Services.EventPipeline`
- [x] Write test checking `Mobius.Services.Shard` is sending the events