### PR TITLE
fix: Preventing a timeout in Shard when asked to reconnect

### DIFF
--- a/lib/mobius/services/socket/gun.ex
+++ b/lib/mobius/services/socket/gun.ex
@@ -37,7 +37,7 @@ defmodule Mobius.Services.Socket.Gun do
   @impl Socket
   @spec close(GenServer.server()) :: :ok
   def close(socket) do
-    GenServer.call(socket, :close)
+    GenServer.cast(socket, :close)
   end
 
   # GenServer and :gun stuff
@@ -91,9 +91,9 @@ defmodule Mobius.Services.Socket.Gun do
   end
 
   @impl GenServer
-  def handle_call(:close, _from, state) do
+  def handle_cast(:close, state) do
     :ok = :gun.ws_send(state.gun_pid, :close)
-    {:reply, :ok, state}
+    {:noreply, state}
   end
 
   @impl GenServer


### PR DESCRIPTION
For context, what happened is Discord sent an OP 7 Reconnect which meant we had to close the websocket connection and reconnect. So the Shard service does a `GenServer.call/2` on the Socket service which then does a `:gun.ws_send(pid, :close)` and I think `:gun.ws_send/2` blocks until a reply is received or something, because it doesn't return immediately. This causes `GenServer.call/2` to then timeout which causes Shard to crash.

Switching from a call to a cast resolves this issue because Shard won't wait until Socket is done reconnecting.

I'd want a regression test to be making sure this mistake isn't done again, but I'm not sure of how this could work so I haven't done any.