### PR TITLE
feat: Manage ratelimits in the REST client

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_feature.md
@@ -1,0 +1,16 @@
+# New Feature
+
+Describe the problem you're trying to solve:
+
+## Checklist 🚨
+
+If you haven't done all of the following,
+reviewers will likely ask you to do these things anyway.
+Please be considerate to them and make sure you have either
+done all of these things or have a good reason to not do them.
+
+- [ ] My PR's title follows [the conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
+- [ ] I documented the new feature properly
+- [ ] I have added the necessary tests for the feature
+- [ ] I made sure both `mix lint` and `mix test` pass successfully on my computer
+- [ ] I have no `TODO`s left in my code

--- a/lib/mobius/application.ex
+++ b/lib/mobius/application.ex
@@ -15,6 +15,7 @@ defmodule Mobius.Application do
       dynamic_supervisor(Mobius.Supervisor.Heartbeat),
       dynamic_supervisor(Mobius.Supervisor.Shard),
       dynamic_supervisor(Mobius.Supervisor.Socket),
+      {Mobius.Services.RestRatelimiter, []},
       {Mobius.Services.PubSub, []},
       {Mobius.Services.EventPipeline, []},
       {Mobius.Services.Bot, token: System.get_env("MOBIUS_BOT_TOKEN")}

--- a/lib/mobius/rest/client.ex
+++ b/lib/mobius/rest/client.ex
@@ -28,6 +28,7 @@ defmodule Mobius.Rest.Client do
 
     middleware = [
       {Tesla.Middleware.Retry, should_retry: &client_should_retry?/1},
+      Mobius.Rest.Middleware.Ratelimit,
       {Tesla.Middleware.BaseUrl, base_url()},
       Tesla.Middleware.PathParams,
       Tesla.Middleware.JSON,

--- a/lib/mobius/rest/middleware/ratelimit.ex
+++ b/lib/mobius/rest/middleware/ratelimit.ex
@@ -1,0 +1,76 @@
+defmodule Mobius.Rest.Middleware.Ratelimit do
+  @moduledoc false
+
+  alias Mobius.Services.RestRatelimiter
+
+  @behaviour Tesla.Middleware
+
+  @impl Tesla.Middleware
+  def call(%Tesla.Env{} = env, next, _options) do
+    env
+    |> enforce_ratelimit()
+    |> Tesla.run(next)
+    |> update_ratelimits()
+  end
+
+  defp enforce_ratelimit(%Tesla.Env{} = env) do
+    params = Keyword.get(env.opts, :path_params, [])
+
+    bucket = {
+      env.url,
+      Keyword.get(params, :guild_id),
+      Keyword.get(params, :channel_id),
+      Keyword.get(params, :webhook_id)
+    }
+
+    RestRatelimiter.wait_ratelimit("global")
+    RestRatelimiter.wait_ratelimit(bucket)
+
+    # Tag the request's bucket so we know which one to update when we get the response
+    %Tesla.Env{env | opts: Keyword.put(env.opts, :ratelimit_bucket, bucket)}
+  end
+
+  defp update_ratelimits({:error, reason}), do: {:error, reason}
+
+  defp update_ratelimits({:ok, %Tesla.Env{status: 429} = env}) do
+    case env.body do
+      %{"global" => true, "retry_after" => retry_after} ->
+        RestRatelimiter.update_ratelimit("global", "global", 0, retry_after)
+        {:ok, env}
+
+      _ ->
+        update_route_ratelimit(env)
+        {:ok, env}
+    end
+  end
+
+  defp update_ratelimits({:ok, %Tesla.Env{} = env}) do
+    update_route_ratelimit(env)
+    {:ok, env}
+  end
+
+  defp update_route_ratelimit(%Tesla.Env{} = env) do
+    route = Keyword.fetch!(env.opts, :ratelimit_bucket)
+    remaining = Tesla.get_header(env, "x-ratelimit-remaining")
+    reset_after = Tesla.get_header(env, "x-ratelimit-reset-after")
+    bucket = Tesla.get_header(env, "x-ratelimit-bucket")
+
+    update_route_ratelimit(route, bucket, remaining, reset_after)
+  end
+
+  defp update_route_ratelimit(_, nil, _, _), do: nil
+  defp update_route_ratelimit(_, _, nil, _), do: nil
+  defp update_route_ratelimit(_, _, _, nil), do: nil
+
+  defp update_route_ratelimit(route, bucket, remaining, reset_after) do
+    remaining = String.to_integer(remaining)
+    reset_after = parse_reset_after(reset_after)
+    RestRatelimiter.update_ratelimit(route, bucket, remaining, reset_after)
+  end
+
+  defp parse_reset_after(reset_after) do
+    reset_after
+    |> String.replace(".", "")
+    |> String.to_integer()
+  end
+end

--- a/lib/mobius/rest/middleware/ratelimit.ex
+++ b/lib/mobius/rest/middleware/ratelimit.ex
@@ -35,7 +35,7 @@ defmodule Mobius.Rest.Middleware.Ratelimit do
   defp update_ratelimits({:ok, %Tesla.Env{status: 429} = env}) do
     case env.body do
       %{"global" => true, "retry_after" => retry_after} ->
-        RestRatelimiter.update_ratelimit("global", "global", 0, retry_after)
+        RestRatelimiter.update_global_ratelimit(retry_after)
         {:ok, env}
 
       _ ->
@@ -65,7 +65,7 @@ defmodule Mobius.Rest.Middleware.Ratelimit do
   defp update_route_ratelimit(route, bucket, remaining, reset_after) do
     remaining = String.to_integer(remaining)
     reset_after = parse_reset_after(reset_after)
-    RestRatelimiter.update_ratelimit(route, bucket, remaining, reset_after)
+    RestRatelimiter.update_route_ratelimit(route, bucket, remaining, reset_after)
   end
 
   defp parse_reset_after(reset_after) do

--- a/lib/mobius/services/rest_ratelimiter.ex
+++ b/lib/mobius/services/rest_ratelimiter.ex
@@ -1,0 +1,83 @@
+defmodule Mobius.Services.RestRatelimiter do
+  @moduledoc false
+
+  use GenServer
+
+  alias Mobius.Services.ETSShelf
+
+  @type state :: %{bucket_map: %{}, global_limit: nil | integer}
+
+  @spec start_link(keyword) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec update_ratelimit(any, String.t(), integer, integer) :: :ok
+  def update_ratelimit(route, bucket, remaining, reset_after) do
+    reset = System.monotonic_time(:millisecond) + reset_after
+    GenServer.call(__MODULE__, {:update, route, bucket, remaining, reset})
+  end
+
+  @spec wait_ratelimit(any) :: :ok
+  def wait_ratelimit(route) do
+    case GenServer.call(__MODULE__, {:request, route}) do
+      :ok -> :ok
+      {:wait, time} -> Process.sleep(time)
+    end
+  end
+
+  @impl GenServer
+  @spec init(keyword) :: {:ok, state()}
+  def init(_opts) do
+    state = %{
+      bucket_map: %{},
+      global_limit: nil
+    }
+
+    :ok = ETSShelf.create_table(__MODULE__, [:set, :protected])
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_info(:reset_global, state) do
+    {:noreply, %{state | global_limit: nil}}
+  end
+
+  @impl GenServer
+  def handle_call({:update, "global", _, _, reset}, _from, state) do
+    Process.send_after(self(), :reset_global, time_until(reset))
+
+    {:reply, :ok, %{state | global_limit: reset}}
+  end
+
+  def handle_call({:update, route, bucket, remaining, reset}, _from, state) do
+    :ets.insert(__MODULE__, {bucket, remaining, reset})
+
+    {:reply, :ok, register_route(state, route, bucket)}
+  end
+
+  def handle_call({:request, "global"}, _from, state) do
+    case state.global_limit do
+      nil -> {:reply, :ok, state}
+      time -> {:reply, {:wait, time_until(time)}, state}
+    end
+  end
+
+  def handle_call({:request, route}, _from, state) do
+    now = System.monotonic_time(:millisecond)
+
+    case :ets.lookup(__MODULE__, find_bucket(state, route)) do
+      [] -> {:reply, :ok, state}
+      [{_, _, expiration}] when now > expiration -> {:reply, :ok, state}
+      [{_, remaining, _}] when remaining > 0 -> {:reply, :ok, state}
+      [{_, _, expiration}] -> {:reply, {:wait, time_until(expiration)}, state}
+    end
+  end
+
+  defp time_until(time), do: max(0, time - System.monotonic_time(:millisecond))
+
+  defp find_bucket(%{bucket_map: map}, route), do: Map.get(map, route, route)
+
+  defp register_route(state, route, bucket),
+    do: %{state | bucket_map: Map.put(state.bucket_map, route, bucket)}
+end

--- a/lib/mobius/services/rest_ratelimiter.ex
+++ b/lib/mobius/services/rest_ratelimiter.ex
@@ -12,12 +12,14 @@ defmodule Mobius.Services.RestRatelimiter do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
+  @doc "Updates a bucket's remaining ratelimit and tracks the route's bucket for later usage"
   @spec update_ratelimit(any, String.t(), integer, integer) :: :ok
   def update_ratelimit(route, bucket, remaining, reset_after) do
     reset = System.monotonic_time(:millisecond) + reset_after
     GenServer.call(__MODULE__, {:update, route, bucket, remaining, reset})
   end
 
+  @doc "Checks if the route's bucket is known and waits for it to be available if ratelimited"
   @spec wait_ratelimit(any) :: :ok
   def wait_ratelimit(route) do
     case GenServer.call(__MODULE__, {:request, route}) do

--- a/lib/mobius/services/shard.ex
+++ b/lib/mobius/services/shard.ex
@@ -109,8 +109,6 @@ defmodule Mobius.Services.Shard do
 
   # Update the state and execute side effects depending on opcode
   defp process_payload(:dispatch, payload, state) do
-    Logger.debug("Dispatching #{inspect(payload.t)}")
-
     state
     |> update_seq(payload.s)
     |> update_state_by_event(payload)

--- a/test/mobius/rest/middleware/ratelimit_test.exs
+++ b/test/mobius/rest/middleware/ratelimit_test.exs
@@ -10,7 +10,7 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
 
   test "doesn't wait if route still has remaining calls", ctx do
     url = "https://discord.com/api/v6/something"
-    mock(fn %{url: ^url} -> response(2, 50, 0) end)
+    mock(fn %{url: ^url} -> response_with_route_ratelimit(remaining: 2, delay_ms: 50) end)
     Tesla.get(ctx.client, url)
 
     assert_get_time(ctx.client, url, 0)
@@ -18,7 +18,7 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
 
   test "waits until reset-after if route is exhausted", ctx do
     url = "https://discord.com/api/v6/something"
-    mock(fn %{url: ^url} -> response(0, 50, 0) end)
+    mock(fn %{url: ^url} -> response_with_route_ratelimit(remaining: 0, delay_ms: 50) end)
     Tesla.get(ctx.client, url)
 
     assert_get_time(ctx.client, url, 50)
@@ -26,7 +26,7 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
 
   test "waits until reset-after if global ratelimit was exceeded", ctx do
     url = "https://discord.com/api/v6/something"
-    mock(fn %{url: ^url} -> response(0, 100, 50) end)
+    mock(fn %{url: ^url} -> response_with_global_ratelimit(50) end)
     Tesla.get(ctx.client, url)
 
     assert_get_time(ctx.client, url, 50)
@@ -38,7 +38,7 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
 
     mock(fn %{method: :get} ->
       [{:remaining, remaining}] = :ets.lookup(table, :remaining)
-      response(remaining, 50, 0)
+      response_with_route_ratelimit(remaining: remaining, delay_ms: 50)
     end)
 
     # First 2 calls to associate both routes to the same bucket
@@ -60,24 +60,27 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
     |> assert_in_delta(expected_time, 10)
   end
 
-  defp response(remaining, delay, global_delay) do
-    cond do
-      global_delay > 0 ->
-        {429,
-         [
-           {"retry-after", "#{global_delay}"},
-           {"x-ratelimit-global", "true"}
-         ], %{"retry_after" => global_delay, "global" => true}}
+  defp response_with_global_ratelimit(global_delay) do
+    headers = [
+      {"retry-after", "#{global_delay}"},
+      {"x-ratelimit-global", "true"}
+    ]
 
-      remaining < 0 ->
-        {429, headers(0, delay), %{"retry_after" => delay, "global" => false}}
+    {429, headers, %{"retry_after" => global_delay, "global" => true}}
+  end
 
-      true ->
-        {204, headers(remaining, delay), nil}
+  defp response_with_route_ratelimit(opts) do
+    remaining = Keyword.fetch!(opts, :remaining)
+    delay = Keyword.fetch!(opts, :delay_ms)
+
+    if remaining < 0 do
+      {429, make_ratelimit_headers(0, delay), %{"retry_after" => delay, "global" => false}}
+    else
+      {204, make_ratelimit_headers(remaining, delay), nil}
     end
   end
 
-  defp headers(remaining, delay) do
+  defp make_ratelimit_headers(remaining, delay) do
     [
       {"retry-after", "#{delay}"},
       {"x-ratelimit-limit", "5"},

--- a/test/mobius/rest/middleware/ratelimit_test.exs
+++ b/test/mobius/rest/middleware/ratelimit_test.exs
@@ -24,14 +24,6 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
     assert_get_time(ctx.client, url, 50)
   end
 
-  test "waits until reset-after if ratelimit was exceeded", ctx do
-    url = "https://discord.com/api/v6/something"
-    mock(fn %{url: ^url} -> response(-1, 50, 0) end)
-    Tesla.get(ctx.client, url)
-
-    assert_get_time(ctx.client, url, 50)
-  end
-
   test "waits until reset-after if global ratelimit was exceeded", ctx do
     url = "https://discord.com/api/v6/something"
     mock(fn %{url: ^url} -> response(0, 100, 50) end)

--- a/test/mobius/rest/middleware/ratelimit_test.exs
+++ b/test/mobius/rest/middleware/ratelimit_test.exs
@@ -1,0 +1,98 @@
+defmodule Mobius.Rest.Middleware.RatelimitTest do
+  use ExUnit.Case
+
+  import Tesla.Mock
+  import Mobius.Assertions
+
+  alias Mobius.Rest.Middleware.Ratelimit
+
+  setup do: [client: Tesla.client([{Ratelimit, []}], Tesla.Mock)]
+
+  test "doesn't wait if route still has remaining calls", ctx do
+    url = "https://discord.com/api/v6/something"
+    mock(fn %{url: ^url} -> response(2, 50, 0) end)
+    Tesla.get(ctx.client, url)
+
+    assert_get_time(ctx.client, url, 0)
+  end
+
+  test "waits until reset-after if route is exhausted", ctx do
+    url = "https://discord.com/api/v6/something"
+    mock(fn %{url: ^url} -> response(0, 50, 0) end)
+    Tesla.get(ctx.client, url)
+
+    assert_get_time(ctx.client, url, 50)
+  end
+
+  test "waits until reset-after if ratelimit was exceeded", ctx do
+    url = "https://discord.com/api/v6/something"
+    mock(fn %{url: ^url} -> response(-1, 50, 0) end)
+    Tesla.get(ctx.client, url)
+
+    assert_get_time(ctx.client, url, 50)
+  end
+
+  test "waits until reset-after if global ratelimit was exceeded", ctx do
+    url = "https://discord.com/api/v6/something"
+    mock(fn %{url: ^url} -> response(0, 100, 50) end)
+    Tesla.get(ctx.client, url)
+
+    assert_get_time(ctx.client, url, 50)
+  end
+
+  test "waits even if route is different when bucket is the same", ctx do
+    # This table is used to make the mock stateful
+    table = :ets.new(:ratelimit_test, [:private, :set])
+
+    mock(fn %{method: :get} ->
+      [{:remaining, remaining}] = :ets.lookup(table, :remaining)
+      response(remaining, 50, 0)
+    end)
+
+    # First 2 calls to associate both routes to the same bucket
+    :ets.insert(table, {:remaining, 2})
+    Tesla.get(ctx.client, "https://discord.com/api/v6/something")
+    :ets.insert(table, {:remaining, 1})
+    Tesla.get(ctx.client, "https://discord.com/api/v6/different")
+    # Trigger the ratelimit on the bucket
+    :ets.insert(table, {:remaining, 0})
+    Tesla.get(ctx.client, "https://discord.com/api/v6/something")
+
+    assert_get_time(ctx.client, "https://discord.com/api/v6/different", 50)
+  end
+
+  defp assert_get_time(client, url, expected_time) do
+    client
+    |> Tesla.get(url)
+    |> function_time()
+    |> assert_in_delta(expected_time, 10)
+  end
+
+  defp response(remaining, delay, global_delay) do
+    cond do
+      global_delay > 0 ->
+        {429,
+         [
+           {"retry-after", "#{global_delay}"},
+           {"x-ratelimit-global", "true"}
+         ], %{"retry_after" => global_delay, "global" => true}}
+
+      remaining < 0 ->
+        {429, headers(0, delay), %{"retry_after" => delay, "global" => false}}
+
+      true ->
+        {204, headers(remaining, delay), nil}
+    end
+  end
+
+  defp headers(remaining, delay) do
+    [
+      {"retry-after", "#{delay}"},
+      {"x-ratelimit-limit", "5"},
+      {"x-ratelimit-remaining", "#{remaining}"},
+      {"x-ratelimit-reset", "#{System.system_time(:millisecond) + delay}"},
+      {"x-ratelimit-reset-after", "#{delay}"},
+      {"x-ratelimit-bucket", "test-bucket"}
+    ]
+  end
+end

--- a/test/mobius/rest/middleware/ratelimit_test.exs
+++ b/test/mobius/rest/middleware/ratelimit_test.exs
@@ -2,7 +2,7 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
   use ExUnit.Case
 
   import Tesla.Mock
-  import Mobius.Assertions
+  import Mobius.TestUtils
 
   alias Mobius.Rest.Middleware.Ratelimit
 

--- a/test/mobius/services/rest_ratelimiter_test.exs
+++ b/test/mobius/services/rest_ratelimiter_test.exs
@@ -1,17 +1,53 @@
 defmodule Mobius.Services.RestRatelimiterTest do
   use ExUnit.Case
 
-  import Mobius.Fixtures
+  import Mobius.Assertions
 
   alias Mobius.Services.RestRatelimiter
 
   describe "wait_ratelimit/1" do
-    test "doesn't wait for global if never updated"
-    test "waits for global until the reset time"
-    test "uses same limit for different routes with same bucket"
-    test "doesn't wait when never seen the route"
-    test "doesn't wait if route's bucket's limit has expired"
-    test "doesn't wait if route's bucket's limit isn't exhausted"
-    test "waits if route's bucket's limit is exhausted"
+    test "doesn't wait for global if never updated" do
+      assert_wait_time("global", 5)
+    end
+
+    test "waits for global until the reset time" do
+      RestRatelimiter.update_ratelimit("global", "global", 0, 50)
+      assert_wait_time("global", 50)
+    end
+
+    test "uses same limit for different routes with same bucket" do
+      bucket = "test-bucket"
+      RestRatelimiter.update_ratelimit(:route1, bucket, 3, 500)
+      RestRatelimiter.update_ratelimit(:route2, bucket, 2, 500)
+      RestRatelimiter.update_ratelimit(:route1, bucket, 0, 50)
+      assert_wait_time(:route2, 50)
+    end
+
+    test "doesn't wait when never seen the route" do
+      assert_wait_time(:route, 5)
+    end
+
+    test "doesn't wait if route's bucket's limit has expired" do
+      RestRatelimiter.update_ratelimit(:route, "test-bucket", 0, 50)
+      Process.sleep(50)
+      assert_wait_time(:route, 5)
+    end
+
+    test "doesn't wait if route's bucket's limit isn't exhausted" do
+      RestRatelimiter.update_ratelimit(:route, "test-bucket", 1, 50)
+      assert_wait_time(:route, 5)
+    end
+
+    test "waits if route's bucket's limit is exhausted" do
+      RestRatelimiter.update_ratelimit(:route, "test-bucket", 0, 50)
+      assert_wait_time(:route, 50)
+    end
+  end
+
+  defp assert_wait_time(route, expected_time) do
+    route
+    |> RestRatelimiter.wait_ratelimit()
+    |> function_time()
+    |> assert_in_delta(expected_time, 10)
   end
 end

--- a/test/mobius/services/rest_ratelimiter_test.exs
+++ b/test/mobius/services/rest_ratelimiter_test.exs
@@ -1,7 +1,7 @@
 defmodule Mobius.Services.RestRatelimiterTest do
   use ExUnit.Case
 
-  import Mobius.Assertions
+  import Mobius.TestUtils
 
   alias Mobius.Services.RestRatelimiter
 

--- a/test/mobius/services/rest_ratelimiter_test.exs
+++ b/test/mobius/services/rest_ratelimiter_test.exs
@@ -11,15 +11,15 @@ defmodule Mobius.Services.RestRatelimiterTest do
     end
 
     test "waits for global until the reset time" do
-      RestRatelimiter.update_ratelimit("global", "global", 0, 50)
+      RestRatelimiter.update_global_ratelimit(50)
       assert_wait_time("global", 50)
     end
 
     test "uses same limit for different routes with same bucket" do
       bucket = "test-bucket"
-      RestRatelimiter.update_ratelimit(:route1, bucket, 3, 500)
-      RestRatelimiter.update_ratelimit(:route2, bucket, 2, 500)
-      RestRatelimiter.update_ratelimit(:route1, bucket, 0, 50)
+      RestRatelimiter.update_route_ratelimit(:route1, bucket, 3, 500)
+      RestRatelimiter.update_route_ratelimit(:route2, bucket, 2, 500)
+      RestRatelimiter.update_route_ratelimit(:route1, bucket, 0, 50)
       assert_wait_time(:route2, 50)
     end
 
@@ -28,18 +28,18 @@ defmodule Mobius.Services.RestRatelimiterTest do
     end
 
     test "doesn't wait if route's bucket's limit has expired" do
-      RestRatelimiter.update_ratelimit(:route, "test-bucket", 0, 50)
+      RestRatelimiter.update_route_ratelimit(:route, "test-bucket", 0, 50)
       Process.sleep(50)
       assert_wait_time(:route, 5)
     end
 
     test "doesn't wait if route's bucket's limit isn't exhausted" do
-      RestRatelimiter.update_ratelimit(:route, "test-bucket", 1, 50)
+      RestRatelimiter.update_route_ratelimit(:route, "test-bucket", 1, 50)
       assert_wait_time(:route, 5)
     end
 
     test "waits if route's bucket's limit is exhausted" do
-      RestRatelimiter.update_ratelimit(:route, "test-bucket", 0, 50)
+      RestRatelimiter.update_route_ratelimit(:route, "test-bucket", 0, 50)
       assert_wait_time(:route, 50)
     end
   end

--- a/test/mobius/services/rest_ratelimiter_test.exs
+++ b/test/mobius/services/rest_ratelimiter_test.exs
@@ -1,0 +1,17 @@
+defmodule Mobius.Services.RestRatelimiterTest do
+  use ExUnit.Case
+
+  import Mobius.Fixtures
+
+  alias Mobius.Services.RestRatelimiter
+
+  describe "wait_ratelimit/1" do
+    test "doesn't wait for global if never updated"
+    test "waits for global until the reset time"
+    test "uses same limit for different routes with same bucket"
+    test "doesn't wait when never seen the route"
+    test "doesn't wait if route's bucket's limit has expired"
+    test "doesn't wait if route's bucket's limit isn't exhausted"
+    test "waits if route's bucket's limit is exhausted"
+  end
+end

--- a/test/support/assertions.ex
+++ b/test/support/assertions.ex
@@ -1,0 +1,21 @@
+defmodule Mobius.Assertions do
+  @moduledoc false
+
+  @doc """
+  Returns runtime of a function call in milliseconds
+
+  ## Examples
+
+      iex> function_time(Process.sleep(50)) in 45..55
+      true
+  """
+  @spec function_time(any) :: Macro.output()
+  defmacro function_time(function) do
+    quote do
+      fn -> unquote(function) end
+      |> :timer.tc()
+      |> elem(0)
+      |> :erlang.convert_time_unit(:microsecond, :millisecond)
+    end
+  end
+end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -1,4 +1,4 @@
-defmodule Mobius.Assertions do
+defmodule Mobius.TestUtils do
   @moduledoc false
 
   @doc """


### PR DESCRIPTION
The goal of this PR is to make the library follow the requirements detailed in [Discord's HTTP ratelimit documentation](https://discord.com/developers/docs/topics/rate-limits#rate-limits). The only things left to implement later in that documentation page will be detecting when a token becomes invalid and preventing permission issues.

TODO:
- [x] Write `@doc` in `Mobius.Services.RestRatelimiter`
- [x] Tests for `Mobius.Rest.Middleware.Ratelimit`
- [x] Tests for `Mobius.Services.RestRatelimiter`