### PR TITLE
feat: Added connection ratelimiter service

### DIFF
--- a/config/config_test.exs
+++ b/config/config_test.exs
@@ -2,5 +2,6 @@ import Config
 
 config :mobius,
   ratelimiter_impl: Mobius.Stubs.CommandsRatelimiter,
+  connection_ratelimiter_impl: Mobius.Stubs.ConnectionRatelimiter,
   socket_impl: Mobius.Stubs.Socket,
   tesla_adapter: Tesla.Mock

--- a/lib/mobius/application.ex
+++ b/lib/mobius/application.ex
@@ -19,6 +19,8 @@ defmodule Mobius.Application do
       {Mobius.Services.PubSub, []},
       {Mobius.Services.EventPipeline, []},
       {Mobius.Services.CommandsRatelimiter, []},
+      {Mobius.Services.ConnectionRatelimiter,
+       time_between_connections_ms: 5_000, ack_timeout_ms: 10_000},
       {Mobius.Services.Bot, token: System.get_env("MOBIUS_BOT_TOKEN")}
     ]
 

--- a/lib/mobius/application.ex
+++ b/lib/mobius/application.ex
@@ -19,8 +19,7 @@ defmodule Mobius.Application do
       {Mobius.Services.PubSub, []},
       {Mobius.Services.EventPipeline, []},
       {Mobius.Services.CommandsRatelimiter, []},
-      {Mobius.Services.ConnectionRatelimiter,
-       time_between_connections_ms: 5_000, ack_timeout_ms: 10_000},
+      {Mobius.Services.ConnectionRatelimiter, connection_delay_ms: 5_000, ack_timeout_ms: 10_000},
       {Mobius.Services.Bot, token: System.get_env("MOBIUS_BOT_TOKEN")}
     ]
 

--- a/lib/mobius/services/connection_ratelimiter.ex
+++ b/lib/mobius/services/connection_ratelimiter.ex
@@ -1,0 +1,60 @@
+defmodule Mobius.Services.ConnectionRatelimiter do
+  @moduledoc false
+
+  @block_message :connect
+
+  @doc """
+  Unblocks processes waiting in `wait_until_can_connect/0`
+
+  This function is *NOT* for usage in modules other than those implementing this service
+  """
+  @spec unblock_client(pid) :: :ok
+  def unblock_client(pid) do
+    send(pid, @block_message)
+    :ok
+  end
+
+  @spec start_link(keyword) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(impl(), opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @doc """
+  Block the calling process until it has the authorization to connect
+
+  Only one process may connect in any 5 seconds timeframe.
+  Therefore, to ensure the network jitter doesn't cause problems,
+  we will wait until Discord sends us a reply before starting the 5 second timer.
+  This reply is notified through `ack_connected/1`.
+
+  The calling process is also monitored to automatically ack if the process crashes.
+  If the process never acks, but also never crashes,
+  it will automatically ack after a timeout of 10 seconds
+
+  See https://discord.com/developers/docs/topics/gateway#rate-limiting for the few details
+  """
+  @spec wait_until_can_connect() :: :ok
+  def wait_until_can_connect do
+    GenServer.call(__MODULE__, {:connect, self()})
+    block_client()
+  end
+
+  @doc """
+  Ack that the process has succesfully connected to allow the next process to connect
+  """
+  @spec ack_connected() :: :ok
+  def ack_connected do
+    GenServer.cast(__MODULE__, {:connect_ack, self()})
+    :ok
+  end
+
+  defp block_client do
+    receive do
+      @block_message -> :ok
+    end
+  end
+
+  defp impl do
+    Application.get_env(:mobius, :connection_ratelimiter_impl, __MODULE__.Timed)
+  end
+end

--- a/lib/mobius/services/connection_ratelimiter/timed.ex
+++ b/lib/mobius/services/connection_ratelimiter/timed.ex
@@ -1,0 +1,89 @@
+defmodule Mobius.Services.ConnectionRatelimiter.Timed do
+  @moduledoc false
+
+  use GenServer
+
+  alias Mobius.Services.ConnectionRatelimiter
+
+  require Logger
+
+  @type state :: %{
+          queue: :queue.queue(pid),
+          current: pid | nil,
+          time_between_connections_ms: non_neg_integer,
+          timer_ref: reference | nil,
+          monitor_ref: reference | nil
+        }
+
+  # Server callbacks
+  @impl GenServer
+  @spec init(keyword) :: {:ok, state()}
+  def init(opts) do
+    state = %{
+      queue: :queue.new(),
+      current: nil,
+      time_between_connections_ms: Keyword.fetch!(opts, :time_between_connections_ms),
+      timer_ref: nil,
+      monitor_ref: nil
+    }
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call({:connect, pid}, _from, %{current: nil} = state) do
+    ref = unblock_process(pid)
+    {:reply, :ok, %{state | current: pid, monitor_ref: ref}}
+  end
+
+  def handle_call({:connect, pid}, _from, state) do
+    {:reply, :ok, %{state | queue: :queue.in(pid, state.queue)}}
+  end
+
+  @impl GenServer
+  def handle_cast({:connect_ack, pid}, state) do
+    cond do
+      pid != state.current ->
+        Logger.warn("Ack from #{inspect(pid)} when someone else was connecting")
+        {:noreply, state}
+
+      state.timer_ref != nil ->
+        Logger.warn("#{inspect(state.current)} tried to ack again")
+        {:noreply, state}
+
+      true ->
+        Process.demonitor(state.monitor_ref, [:flush])
+        {:noreply, unblock_later(%{state | monitor_ref: nil})}
+    end
+  end
+
+  @impl GenServer
+  def handle_info(:unblock_next, state) do
+    state =
+      case :queue.out(state.queue) do
+        {{:value, pid}, queue} ->
+          ref = unblock_process(pid)
+          %{state | current: pid, queue: queue, monitor_ref: ref}
+
+        {:empty, _q} ->
+          %{state | current: nil}
+      end
+
+    {:noreply, %{state | timer_ref: nil}}
+  end
+
+  def handle_info({:DOWN, _, _, pid, _}, %{current: conn_pid} = state) when pid == conn_pid do
+    {:noreply, unblock_later(%{state | monitor_ref: nil})}
+  end
+
+  defp unblock_later(state) do
+    ref = Process.send_after(self(), :unblock_next, state.time_per_connection_ms)
+    %{state | timer_ref: ref}
+  end
+
+  defp unblock_process(pid) do
+    ref = Process.monitor(pid)
+    ConnectionRatelimiter.unblock_client(pid)
+    ref
+  end
+end

--- a/lib/mobius/services/connection_ratelimiter/timed.ex
+++ b/lib/mobius/services/connection_ratelimiter/timed.ex
@@ -57,16 +57,16 @@ defmodule Mobius.Services.ConnectionRatelimiter.Timed do
         {:noreply, state}
 
       true ->
+        Process.cancel_timer(state.timeout_ref)
         Process.demonitor(state.monitor_ref, [:flush])
-        {:noreply, unblock_later(%{state | monitor_ref: nil})}
+        {:noreply, unblock_later(%{state | monitor_ref: nil, timeout_ref: nil})}
     end
   end
 
   @impl GenServer
   def handle_info(:ack_timeout, state) do
-    Process.cancel_timer(state.timeout_ref)
     GenServer.cast(__MODULE__, {:connect_ack, self()})
-    {:noreply, %{state | timeout_ref: nil}}
+    {:noreply, state}
   end
 
   def handle_info(:unblock_next, state) do

--- a/test/mobius/services/connection_ratelimiter/timed_test.exs
+++ b/test/mobius/services/connection_ratelimiter/timed_test.exs
@@ -21,7 +21,7 @@ defmodule Mobius.Services.ConnectionRatelimiter.TimedTest do
 
     test "executes callbacks a delay after the previous ack" do
       Timed.wait_until_can_connect(make_callback())
-      assert_received :callback_called
+      assert_callback_called(0)
       Timed.ack_connected()
       Timed.wait_until_can_connect(make_callback())
 
@@ -30,7 +30,7 @@ defmodule Mobius.Services.ConnectionRatelimiter.TimedTest do
 
     test "executes callbacks a delay after the previous ack timed out" do
       Timed.wait_until_can_connect(make_callback())
-      assert_received :callback_called
+      assert_callback_called(0)
       Timed.wait_until_can_connect(make_callback())
 
       assert_callback_called(@ack_timeout + @connection_delay)

--- a/test/mobius/services/connection_ratelimiter/timed_test.exs
+++ b/test/mobius/services/connection_ratelimiter/timed_test.exs
@@ -7,13 +7,9 @@ defmodule Mobius.Services.ConnectionRatelimiter.TimedTest do
   @ack_timeout 50
 
   setup do
-    # Manually start the service because it won't be started during tests
-    # This also means it's restarted on every test
-    # which means tests won't wait for the previous one to ack
-    start_supervised!(
-      {Timed, connection_delay_ms: @connection_delay, ack_timeout_ms: @ack_timeout}
-    )
-
+    # Manually start the service on each test because it won't be started at all during tests
+    service = {Timed, connection_delay_ms: @connection_delay, ack_timeout_ms: @ack_timeout}
+    start_supervised!(service)
     :ok
   end
 

--- a/test/mobius/services/connection_ratelimiter/timed_test.exs
+++ b/test/mobius/services/connection_ratelimiter/timed_test.exs
@@ -1,0 +1,68 @@
+defmodule Mobius.Services.ConnectionRatelimiter.TimedTest do
+  use ExUnit.Case
+
+  alias Mobius.Services.ConnectionRatelimiter.Timed
+
+  @connection_delay 30
+  @ack_timeout 50
+
+  setup do
+    # Manually start the service because it won't be started during tests
+    # This also means it's restarted on every test
+    # which means tests won't wait for the previous one to ack
+    start_supervised!(
+      {Timed, connection_delay_ms: @connection_delay, ack_timeout_ms: @ack_timeout}
+    )
+
+    :ok
+  end
+
+  describe "wait_until_can_connect/1" do
+    test "executes the first callback immediately" do
+      Timed.wait_until_can_connect(make_callback())
+      assert_callback_called(0)
+    end
+
+    test "executes callbacks a delay after the previous ack" do
+      Timed.wait_until_can_connect(make_callback())
+      assert_received :callback_called
+      Timed.ack_connected()
+      Timed.wait_until_can_connect(make_callback())
+
+      assert_callback_called(@connection_delay)
+    end
+
+    test "executes callbacks a delay after the previous ack timed out" do
+      Timed.wait_until_can_connect(make_callback())
+      assert_received :callback_called
+      Timed.wait_until_can_connect(make_callback())
+
+      assert_callback_called(@ack_timeout + @connection_delay)
+    end
+
+    test "executes callbacks a delay after the previous ack'er died" do
+      # Start a task which connects then dies without ack'ing
+      # and await that task to make the test wait for the task before continuing
+      fn -> Timed.wait_until_can_connect(fn -> nil end) end
+      |> Task.async()
+      |> Task.await()
+
+      Timed.wait_until_can_connect(make_callback())
+
+      assert_callback_called(@connection_delay)
+    end
+  end
+
+  defp assert_callback_called(0), do: assert_received(:callback_called)
+
+  defp assert_callback_called(expected_time) do
+    # Assert we receive at the expected time +- 10ms
+    Process.sleep(expected_time - 10)
+    assert_receive :callback_called, 20
+  end
+
+  defp make_callback do
+    pid = self()
+    fn -> send(pid, :callback_called) end
+  end
+end

--- a/test/support/commands_ratelimiter_stub.ex
+++ b/test/support/commands_ratelimiter_stub.ex
@@ -36,7 +36,7 @@ defmodule Mobius.Stubs.CommandsRatelimiter do
     GenServer.call(__MODULE__, {:set_test, self()})
   end
 
-  # GenServer and :gun stuff
+  # GenServer stuff
   @impl GenServer
   @spec init(keyword) :: {:ok, state()}
   def init(_opts) do

--- a/test/support/connection_ratelimiter_stub.ex
+++ b/test/support/connection_ratelimiter_stub.ex
@@ -1,0 +1,62 @@
+defmodule Mobius.Stubs.ConnectionRatelimiter do
+  @moduledoc false
+
+  use GenServer
+
+  alias Mobius.Services.ConnectionRatelimiter
+
+  @type state :: %{
+          test_pid: pid | nil
+        }
+
+  # Stub API
+  @spec set_owner() :: :ok
+  def set_owner do
+    GenServer.call(ConnectionRatelimiter, {:set_test, self()})
+  end
+
+  # GenServer stuff
+  @impl GenServer
+  @spec init(keyword) :: {:ok, state()}
+  def init(_opts) do
+    state = %{
+      test_pid: nil
+    }
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_cast({:connect_ack, pid}, state) do
+    if state.test_pid != nil do
+      send(state.test_pid, {:connection_ack, pid})
+    end
+
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_call({:connect, pid}, _from, state) do
+    if state.test_pid != nil do
+      send(state.test_pid, {:connection_request, pid})
+    end
+
+    {:reply, :ok, state}
+  end
+
+  # Stub-only callbacks
+  def handle_call({:set_test, pid}, _from, %{test_pid: nil} = state) do
+    Process.monitor(pid)
+    {:reply, :ok, put_in(state.test_pid, pid)}
+  end
+
+  def handle_call({:set_test, _pid}, _from, state) do
+    {:reply, {:error, :already_assigned}, state}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, %{test_pid: t_pid} = state)
+      when pid == t_pid do
+    {:noreply, put_in(state.test_pid, nil)}
+  end
+end

--- a/test/support/connection_ratelimiter_stub.ex
+++ b/test/support/connection_ratelimiter_stub.ex
@@ -34,7 +34,7 @@ defmodule Mobius.Stubs.ConnectionRatelimiter do
   # Stub API
   @spec set_owner() :: :ok
   def set_owner do
-    GenServer.call(ConnectionRatelimiter, {:set_test, self()})
+    GenServer.call(__MODULE__, {:set_test, self()})
   end
 
   # GenServer stuff


### PR DESCRIPTION
As [documented here](https://discord.com/developers/docs/topics/gateway#rate-limiting), Discord ratelimits the number of `Identify` it receives to a maximum of 1* per 5 seconds. To prevent network jitter from making this library accidentally break this limit, the library will instead wait until we receive a response from Discord before counting those 5 seconds. This makes the bot slower to identify on all shards if there is network jitter, but guarantees that we won't exceed the limit. This "wait for a response" is a design decision, not a requirement.

*The limit of *one* per 5 seconds is actually a concurrency limit specified in the [session start limit](https://discord.com/developers/docs/topics/gateway#session-start-limit-object) and can potentially be more than 1 though that's a maximum so a bot not using the maximum would still work properly, it would only identify very slowly if it has many shards.

TODO:
- [x] ~Support an arbitrary concurrency (currently only 1)~ Won't do now, this part isn't a top priority
- [x] Add a timeout to the ack
- [x] Use `Mobius.Services.ConnectionRatelimiter` where appropriate
- [x] Add tests for `Mobius.Services.ConnectionRatelimiter.Timed`
- [x] Add tests for the usages of `Mobius.Services.ConnectionRatelimiter`