### PR TITLE
test: Tuning tests' execution speed

### DIFF
--- a/config/config_test.exs
+++ b/config/config_test.exs
@@ -1,5 +1,9 @@
 import Config
 
+config :ex_unit,
+  assert_receive_timeout: 50,
+  refute_receive_timeout: 50
+
 config :mobius,
   ratelimiter_impl: Mobius.Stubs.CommandsRatelimiter,
   socket_impl: Mobius.Stubs.Socket,

--- a/lib/mobius/rest/client.ex
+++ b/lib/mobius/rest/client.ex
@@ -16,6 +16,7 @@ defmodule Mobius.Rest.Client do
   @spec new(keyword) :: client()
   def new(opts) do
     token = Keyword.fetch!(opts, :token)
+    retries = Keyword.get(opts, :max_retries, 5)
 
     headers = [
       {"User-Agent",
@@ -27,7 +28,7 @@ defmodule Mobius.Rest.Client do
     ]
 
     middleware = [
-      {Tesla.Middleware.Retry, should_retry: &client_should_retry?/1},
+      {Tesla.Middleware.Retry, max_retries: retries, should_retry: &client_should_retry?/1},
       Mobius.Rest.Middleware.Ratelimit,
       {Tesla.Middleware.BaseUrl, base_url()},
       Tesla.Middleware.PathParams,

--- a/test/mobius/services/heartbeat_test.exs
+++ b/test/mobius/services/heartbeat_test.exs
@@ -11,11 +11,11 @@ defmodule Mobius.Services.HeartbeatTest do
   setup :stub_socket
 
   test "sends heartbeat regularly" do
-    send_hello(500)
+    send_hello(50)
     assert_received_heartbeat(0)
     send_payload(op: :heartbeat_ack)
 
-    Process.sleep(500)
+    Process.sleep(50)
     assert_received_heartbeat(0)
     send_payload(op: :heartbeat_ack)
   end
@@ -30,11 +30,11 @@ defmodule Mobius.Services.HeartbeatTest do
   end
 
   test "closes the socket if no ack since last heartbeat" do
-    send_hello(500)
+    send_hello(50)
 
     assert_received_heartbeat(0)
-    Process.sleep(500)
-    assert_receive :socket_close, 100
+    Process.sleep(50)
+    assert_receive :socket_close, 20
   end
 
   test "updates ping when receives an ack", ctx do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -56,7 +56,7 @@ defmodule Mobius.Fixtures do
   end
 
   def create_rest_client(context) do
-    [client: Client.new(token: context.token)]
+    [client: Client.new(token: context.token, max_retries: 0)]
   end
 
   # Utility functions


### PR DESCRIPTION
I looked at the top 3 from `mix test --slowest 3` and fixed the issue then ran `mix test --slowest 3` again until I couldn't find an obvious way to make the tests run faster.

Basically a lot of tests were just sleeping for way too long for no obvious reason (should've documented the reason if there was any). This could make tests more brittle on slower computers (hopefully not the CI), but will increase developer productivity without much effort. Because the configs changed are global, this also makes future tests faster.

I played with `assert_receive_timeout` and `refute_receive_timeout`. I changed them down to 25ms, but it only reduced execution time by .3s which I judged as not worth the increased brittleness. I think 50ms is a good compromise between increased speed and brittleness (compared its default value of 200ms).

The other notable change is the rest client. Since the retry was added, it caused a handful of tests which voluntarily caused errors to be retried multiple times even though the result would never change during tests. I therefore made the number of retries be a config and set it to 0 for tests. This made 2 tests go from taking up to 1s to taking a few ms instead. Definitely a good gain there.

Overall these changes made the tests go from about 6 seconds of execution time to about 1.7 seconds on my machine.