### PR TITLE
feat: Handling token revokes

### DIFF
--- a/lib/mobius/core/socket_codes.ex
+++ b/lib/mobius/core/socket_codes.ex
@@ -10,7 +10,7 @@ defmodule Mobius.Core.SocketCodes do
     4000 => {"Unknown error", :resume},
     4001 => {"Unknown opcode", :dont_resume},
     4002 => {"Decode error", :resume},
-    4003 => {"Not authenticated", :dont_resume},
+    4003 => {"Not authenticated", :dont_reconnect},
     4004 => {"Authentication failed", :dont_reconnect},
     4005 => {"Already authenticated", :dont_resume},
     4007 => {"Invalid seq", :dont_resume},

--- a/lib/mobius/rest/client.ex
+++ b/lib/mobius/rest/client.ex
@@ -70,7 +70,10 @@ defmodule Mobius.Rest.Client do
   defp check_status(%Tesla.Env{status: 200, body: body}), do: {:ok, body}
   defp check_status(%Tesla.Env{} = env), do: {:error, env.status, env.body}
 
+  defp client_should_retry?({:error, :forbidden}), do: false
+  defp client_should_retry?({:error, :unauthorized_token}), do: false
   defp client_should_retry?({:error, _}), do: true
+  defp client_should_retry?({:error, error, _}), do: error in [:bad_request]
   defp client_should_retry?({:ok, %{status: status}}) when status in [429, 500, 502], do: true
   defp client_should_retry?({:ok, _}), do: false
 end


### PR DESCRIPTION
4003 is sent immediately when the token is revoked, so forcing a "no-reconnect" policy on it means we stop receiving events from Discord which should stop most interactions happening. There's still a possibility of a background task doing http requests or a delayed interaction happening, but it should be fine for most cases. This solution is only temporary anyway. Once the token is moved elsewhere we'll be able to implement a more proper solution.

Shutting down BEAM was an option until I thought about the impact it would have on tests. It makes it complicated to test and this is a temporary solution anyway so it wasn't worth the effort.

I also changed a bit of the retry logic on http requests so requests whose result won't change after a retry aren't retried.