### PR TITLE
chore: Update Renovate range strategy to "bump"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,4 +11,5 @@
       "groupName": "non-major dependencies"
     }
   ]
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
Updates Renovate-bot's range strategy to "bump" (from the default "replace").

"replace" only updates the dependencies when they no longer match the rule specified in the project (ie `~> 1.10` would only be updated when a version `>= 2.0.0` is released), whereas "bump" will always update to the latest compatible range specification (see https://docs.renovatebot.com/configuration-options/#rangestrategy for more information about the "rangeStrategy" configuration).