### PR TITLE
feat: Switched to API v8

### DIFF
--- a/lib/mobius/rest/client.ex
+++ b/lib/mobius/rest/client.ex
@@ -9,7 +9,7 @@ defmodule Mobius.Rest.Client do
   @type result(arg) :: {:ok, arg} | error()
 
   @lib_url "https://github.com/ZeLarpMaster/Mobius"
-  @api_vsn 6
+  @api_vsn 8
 
   defguardp is_not_error(value) when not is_tuple(value) or elem(value, 0) != :error
 
@@ -23,7 +23,6 @@ defmodule Mobius.Rest.Client do
        "DiscordBot" <>
          " (#{@lib_url}, #{Application.spec(:mobius, :vsn)}" <>
          " Elixir/#{System.version()}"},
-      {"X-RateLimit-Precision", "millisecond"},
       {"Authorization", "Bot #{token}"}
     ]
 

--- a/lib/mobius/services/shard.ex
+++ b/lib/mobius/services/shard.ex
@@ -16,7 +16,7 @@ defmodule Mobius.Services.Shard do
 
   require Logger
 
-  @gateway_version "6"
+  @gateway_version "8"
 
   @typep state :: %{
            gateway: Gateway.t(),

--- a/test/mobius/rest/middleware/ratelimit_test.exs
+++ b/test/mobius/rest/middleware/ratelimit_test.exs
@@ -9,7 +9,7 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
   setup do: [client: Tesla.client([{Ratelimit, []}], Tesla.Mock)]
 
   test "doesn't wait if route still has remaining calls", ctx do
-    url = "https://discord.com/api/v6/something"
+    url = "https://discord.com/api/something"
     mock(fn %{url: ^url} -> response_with_route_ratelimit(remaining: 2, delay_ms: 50) end)
     Tesla.get(ctx.client, url)
 
@@ -17,7 +17,7 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
   end
 
   test "waits until reset-after if route is exhausted", ctx do
-    url = "https://discord.com/api/v6/something"
+    url = "https://discord.com/api/something"
     mock(fn %{url: ^url} -> response_with_route_ratelimit(remaining: 0, delay_ms: 50) end)
     Tesla.get(ctx.client, url)
 
@@ -25,7 +25,7 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
   end
 
   test "waits until reset-after if global ratelimit was exceeded", ctx do
-    url = "https://discord.com/api/v6/something"
+    url = "https://discord.com/api/something"
     mock(fn %{url: ^url} -> response_with_global_ratelimit(50) end)
     Tesla.get(ctx.client, url)
 
@@ -43,14 +43,14 @@ defmodule Mobius.Rest.Middleware.RatelimitTest do
 
     # First 2 calls to associate both routes to the same bucket
     :ets.insert(table, {:remaining, 2})
-    Tesla.get(ctx.client, "https://discord.com/api/v6/something")
+    Tesla.get(ctx.client, "https://discord.com/api/something")
     :ets.insert(table, {:remaining, 1})
-    Tesla.get(ctx.client, "https://discord.com/api/v6/different")
+    Tesla.get(ctx.client, "https://discord.com/api/different")
     # Trigger the ratelimit on the bucket
     :ets.insert(table, {:remaining, 0})
-    Tesla.get(ctx.client, "https://discord.com/api/v6/something")
+    Tesla.get(ctx.client, "https://discord.com/api/something")
 
-    assert_get_time(ctx.client, "https://discord.com/api/v6/different", 50)
+    assert_get_time(ctx.client, "https://discord.com/api/different", 50)
   end
 
   defp assert_get_time(client, url, expected_time) do


### PR DESCRIPTION
Closes #31 

Manual testing tells me nothing broke, which is to be expected since we didn't actually implement most of the things which changed. The full changelog of v8 can be found here: https://discord.com/developers/docs/change-log#api-and-gateway-v8