### PR TITLE
feat(models): Added Embed

### DIFF
--- a/lib/mobius/models/embed.ex
+++ b/lib/mobius/models/embed.ex
@@ -1,0 +1,82 @@
+defmodule Mobius.Models.Embed do
+  @moduledoc """
+  Struct for Discord's Embed
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/channel#embed-object
+  """
+
+  import Mobius.Models.Utils
+
+  alias Mobius.Models.Timestamp
+
+  defstruct [
+    :title,
+    :type,
+    :description,
+    :url,
+    :timestamp,
+    :color,
+    :footer,
+    :image,
+    :thumbnail,
+    :video,
+    :provider,
+    :author,
+    :fields
+  ]
+
+  @type type ::
+          :image
+          | :video
+          | :gifv
+          | :article
+          | :link
+
+  @type t :: %__MODULE__{
+          title: String.t() | nil,
+          type: type() | nil,
+          description: String.t() | nil,
+          url: String.t() | nil,
+          timestamp: DateTime.t() | nil,
+          color: non_neg_integer() | nil,
+          footer: __MODULE__.Footer.t() | nil,
+          image: __MODULE__.Media.t() | nil,
+          thumbnail: __MODULE__.Media.t() | nil,
+          video: __MODULE__.Media.t() | nil,
+          provider: __MODULE__.Provider.t() | nil,
+          author: __MODULE__.Author.t() | nil,
+          fields: [__MODULE__.Field.t()] | nil
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :title)
+    |> add_field(map, :type, &parse_type/1)
+    |> add_field(map, :description)
+    |> add_field(map, :url)
+    |> add_field(map, :timestamp, &Timestamp.parse/1)
+    |> add_field(map, :color)
+    |> add_field(map, :footer, &__MODULE__.Footer.parse/1)
+    |> add_field(map, :image, &__MODULE__.Media.parse/1)
+    |> add_field(map, :thumbnail, &__MODULE__.Media.parse/1)
+    |> add_field(map, :video, &__MODULE__.Media.parse/1)
+    |> add_field(map, :provider, &__MODULE__.Provider.parse/1)
+    |> add_field(map, :author, &__MODULE__.Author.parse/1)
+    |> add_field(map, :fields, &parse_fields/1)
+  end
+
+  def parse(_), do: nil
+
+  defp parse_type("rich"), do: :rich
+  defp parse_type("image"), do: :image
+  defp parse_type("video"), do: :video
+  defp parse_type("gifv"), do: :gifv
+  defp parse_type("article"), do: :article
+  defp parse_type("link"), do: :link
+  defp parse_type(_), do: nil
+
+  defp parse_fields(value), do: parse_list(value, &__MODULE__.Field.parse/1)
+end

--- a/lib/mobius/models/embed.ex
+++ b/lib/mobius/models/embed.ex
@@ -28,6 +28,7 @@ defmodule Mobius.Models.Embed do
 
   @type type ::
           :image
+          | :rich
           | :video
           | :gifv
           | :article

--- a/lib/mobius/models/embed/author.ex
+++ b/lib/mobius/models/embed/author.ex
@@ -1,0 +1,36 @@
+defmodule Mobius.Models.Embed.Author do
+  @moduledoc """
+  Struct for Discord's Embed's Author
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/channel#embed-object-embed-author-structure
+  """
+
+  import Mobius.Models.Utils
+
+  defstruct [
+    :name,
+    :url,
+    :icon_url,
+    :proxy_icon_url
+  ]
+
+  @type t :: %__MODULE__{
+          name: String.t() | nil,
+          url: String.t() | nil,
+          icon_url: String.t() | nil,
+          proxy_icon_url: String.t() | nil
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :name)
+    |> add_field(map, :url)
+    |> add_field(map, :icon_url)
+    |> add_field(map, :proxy_icon_url)
+  end
+
+  def parse(_), do: nil
+end

--- a/lib/mobius/models/embed/field.ex
+++ b/lib/mobius/models/embed/field.ex
@@ -1,0 +1,33 @@
+defmodule Mobius.Models.Embed.Field do
+  @moduledoc """
+  Struct for Discord's Embed's Field
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure
+  """
+
+  import Mobius.Models.Utils
+
+  defstruct [
+    :name,
+    :value,
+    :inline
+  ]
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          value: String.t(),
+          inline: boolean | nil
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :name)
+    |> add_field(map, :value)
+    |> add_field(map, :inline)
+  end
+
+  def parse(_), do: nil
+end

--- a/lib/mobius/models/embed/footer.ex
+++ b/lib/mobius/models/embed/footer.ex
@@ -1,0 +1,33 @@
+defmodule Mobius.Models.Embed.Footer do
+  @moduledoc """
+  Struct for Discord's Embed's Footer
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure
+  """
+
+  import Mobius.Models.Utils
+
+  defstruct [
+    :text,
+    :icon_url,
+    :proxy_icon_url
+  ]
+
+  @type t :: %__MODULE__{
+          text: String.t(),
+          icon_url: String.t() | nil,
+          proxy_icon_url: String.t() | nil
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :text)
+    |> add_field(map, :icon_url)
+    |> add_field(map, :proxy_icon_url)
+  end
+
+  def parse(_), do: nil
+end

--- a/lib/mobius/models/embed/media.ex
+++ b/lib/mobius/models/embed/media.ex
@@ -1,0 +1,40 @@
+defmodule Mobius.Models.Embed.Media do
+  @moduledoc """
+  Struct for Discord's Embed's Image, Thumbnail, and Video
+
+  All three have the exact same fields with the exact same types
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/channel#embed-object-embed-image-structure
+  https://discord.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure
+  https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure
+  """
+
+  import Mobius.Models.Utils
+
+  defstruct [
+    :url,
+    :proxy_url,
+    :height,
+    :width
+  ]
+
+  @type t :: %__MODULE__{
+          url: String.t() | nil,
+          proxy_url: String.t() | nil,
+          height: non_neg_integer() | nil,
+          width: non_neg_integer() | nil
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :url)
+    |> add_field(map, :proxy_url)
+    |> add_field(map, :height)
+    |> add_field(map, :width)
+  end
+
+  def parse(_), do: nil
+end

--- a/lib/mobius/models/embed/provider.ex
+++ b/lib/mobius/models/embed/provider.ex
@@ -1,0 +1,30 @@
+defmodule Mobius.Models.Embed.Provider do
+  @moduledoc """
+  Struct for Discord's Embed's Provider
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/channel#embed-object-embed-provider-structure
+  """
+
+  import Mobius.Models.Utils
+
+  defstruct [
+    :name,
+    :url
+  ]
+
+  @type t :: %__MODULE__{
+          name: String.t() | nil,
+          url: String.t() | nil
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :name)
+    |> add_field(map, :url)
+  end
+
+  def parse(_), do: nil
+end

--- a/lib/mobius/models/member.ex
+++ b/lib/mobius/models/member.ex
@@ -8,8 +8,8 @@ defmodule Mobius.Models.Member do
 
   import Mobius.Models.Utils
 
-  alias Mobius.Models.DateTime, as: DateTimeModel
   alias Mobius.Models.Snowflake
+  alias Mobius.Models.Timestamp
   alias Mobius.Models.User
 
   defstruct [
@@ -41,8 +41,8 @@ defmodule Mobius.Models.Member do
     |> add_field(map, :user, &User.parse/1)
     |> add_field(map, :nick)
     |> add_field(map, :roles, &parse_roles/1)
-    |> add_field(map, :joined_at, &DateTimeModel.parse/1)
-    |> add_field(map, :premium_since, &DateTimeModel.parse/1)
+    |> add_field(map, :joined_at, &Timestamp.parse/1)
+    |> add_field(map, :premium_since, &Timestamp.parse/1)
     |> add_field(map, :deaf)
     |> add_field(map, :mute)
     |> add_field(map, :pending)

--- a/lib/mobius/models/timestamp.ex
+++ b/lib/mobius/models/timestamp.ex
@@ -1,4 +1,4 @@
-defmodule Mobius.Models.DateTime do
+defmodule Mobius.Models.Timestamp do
   @moduledoc false
 
   @doc """

--- a/test/mobius/models/datetime_test.exs
+++ b/test/mobius/models/datetime_test.exs
@@ -1,5 +1,0 @@
-defmodule Mobius.Models.DateTimeTest do
-  use ExUnit.Case, async: true
-
-  doctest Mobius.Models.DateTime, import: true
-end

--- a/test/mobius/models/embed_test.exs
+++ b/test/mobius/models/embed_test.exs
@@ -1,0 +1,62 @@
+defmodule Mobius.Models.EmbedTest do
+  use ExUnit.Case, async: true
+
+  import Mobius.Generators
+  import Mobius.TestUtils
+
+  alias Mobius.Models.Embed
+  alias Mobius.Models.Embed.Author
+  alias Mobius.Models.Embed.Field
+  alias Mobius.Models.Embed.Footer
+  alias Mobius.Models.Embed.Media
+  alias Mobius.Models.Embed.Provider
+  alias Mobius.Models.Timestamp
+  alias Mobius.Models.Utils
+
+  describe "parse/1" do
+    test "returns nil for non-maps" do
+      assert nil == Embed.parse("string")
+      assert nil == Embed.parse(42)
+      assert nil == Embed.parse(true)
+      assert nil == Embed.parse(nil)
+    end
+
+    test "defaults to nil for all fields" do
+      %{}
+      |> Embed.parse()
+      |> assert_field(:title, nil)
+      |> assert_field(:type, nil)
+      |> assert_field(:description, nil)
+      |> assert_field(:url, nil)
+      |> assert_field(:timestamp, nil)
+      |> assert_field(:color, nil)
+      |> assert_field(:footer, nil)
+      |> assert_field(:image, nil)
+      |> assert_field(:thumbnail, nil)
+      |> assert_field(:video, nil)
+      |> assert_field(:provider, nil)
+      |> assert_field(:author, nil)
+      |> assert_field(:fields, nil)
+    end
+
+    test "parses all fields as expected" do
+      map = embed()
+
+      map
+      |> Embed.parse()
+      |> assert_field(:title, map["title"])
+      |> assert_field(:type, :rich)
+      |> assert_field(:description, map["description"])
+      |> assert_field(:url, map["url"])
+      |> assert_field(:timestamp, Timestamp.parse(map["timestamp"]))
+      |> assert_field(:color, map["color"])
+      |> assert_field(:footer, Footer.parse(map["footer"]))
+      |> assert_field(:image, Media.parse(map["image"]))
+      |> assert_field(:thumbnail, Media.parse(map["thumbnail"]))
+      |> assert_field(:video, Media.parse(map["video"]))
+      |> assert_field(:provider, Provider.parse(map["provider"]))
+      |> assert_field(:author, Author.parse(map["author"]))
+      |> assert_field(:fields, Utils.parse_list(map["fields"], &Field.parse/1))
+    end
+  end
+end

--- a/test/mobius/models/member_test.exs
+++ b/test/mobius/models/member_test.exs
@@ -4,9 +4,9 @@ defmodule Mobius.Models.MemberTest do
   import Mobius.Generators
   import Mobius.TestUtils
 
-  alias Mobius.Models.DateTime
   alias Mobius.Models.Member
   alias Mobius.Models.Snowflake
+  alias Mobius.Models.Timestamp
   alias Mobius.Models.User
   alias Mobius.Models.Utils
 
@@ -39,8 +39,8 @@ defmodule Mobius.Models.MemberTest do
       |> assert_field(:user, User.parse(map["user"]))
       |> assert_field(:nick, map["nick"])
       |> assert_field(:roles, Utils.parse_list(map["roles"], &Snowflake.parse/1))
-      |> assert_field(:joined_at, DateTime.parse(map["joined_at"]))
-      |> assert_field(:premium_since, DateTime.parse(map["premium_since"]))
+      |> assert_field(:joined_at, Timestamp.parse(map["joined_at"]))
+      |> assert_field(:premium_since, Timestamp.parse(map["premium_since"]))
       |> assert_field(:deaf, map["deaf"])
       |> assert_field(:mute, map["mute"])
       |> assert_field(:pending, map["pending"])

--- a/test/mobius/models/timestamp_test.exs
+++ b/test/mobius/models/timestamp_test.exs
@@ -1,0 +1,5 @@
+defmodule Mobius.Models.TimestampTest do
+  use ExUnit.Case, async: true
+
+  doctest Mobius.Models.Timestamp, import: true
+end

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -100,6 +100,27 @@ defmodule Mobius.Generators do
     merge_opts(defaults, opts)
   end
 
+  @spec embed(keyword) :: map
+  def embed(opts \\ []) do
+    defaults = %{
+      "title" => random_hex(8),
+      "type" => "rich",
+      "description" => random_hex(16),
+      "url" => random_hex(8),
+      "timestamp" => DateTime.to_iso8601(DateTime.utc_now()),
+      "color" => :rand.uniform(256 * 256 * 256),
+      "footer" => %{"text" => random_hex(8)},
+      "image" => %{"url" => random_hex(8)},
+      "thumbnail" => %{"url" => random_hex(8)},
+      "video" => %{"url" => random_hex(8)},
+      "provider" => %{"name" => random_hex(8), "url" => random_hex(8)},
+      "author" => %{"name" => random_hex(8), "url" => random_hex(8), "icon_url" => random_hex(8)},
+      "fields" => [%{"name" => random_hex(8), "value" => random_hex(8), "inline" => true}]
+    }
+
+    merge_opts(defaults, opts)
+  end
+
   @spec application(keyword) :: map
   def application(opts \\ []) do
     team_id = random_snowflake()


### PR DESCRIPTION
Same thing as #37 but for Embed

Just like #37, this is a part of #28 which was updated during development.

Note: This also includes the renaming of `Mobius.Models.DateTime` --> `Mobius.Models.Timestamp` because it conflicted with `Elixir.DateTime` which made it annoying to use.