### PR TITLE
feat(models): Added GuildPreview

### DIFF
--- a/lib/mobius/models/ban.ex
+++ b/lib/mobius/models/ban.ex
@@ -1,0 +1,32 @@
+defmodule Mobius.Models.Ban do
+  @moduledoc """
+  Struct for Discord's Ban
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/guild#ban-object
+  """
+
+  import Mobius.Models.Utils
+
+  alias Mobius.Models.User
+
+  defstruct [
+    :reason,
+    :user
+  ]
+
+  @type t :: %__MODULE__{
+          reason: String.t() | nil,
+          user: User.t()
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :reason)
+    |> add_field(map, :user, &User.parse/1)
+  end
+
+  def parse(_), do: nil
+end

--- a/lib/mobius/models/guild_preview.ex
+++ b/lib/mobius/models/guild_preview.ex
@@ -1,0 +1,62 @@
+defmodule Mobius.Models.GuildPreview do
+  @moduledoc """
+  Struct for Discord's Guild Preview
+
+  You can find a list of `features` here:
+  https://discord.com/developers/docs/resources/guild#guild-object-guild-features
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/guild#guild-preview-object
+  """
+
+  import Mobius.Models.Utils
+
+  alias Mobius.Models.Emoji
+  alias Mobius.Models.Snowflake
+
+  defstruct [
+    :id,
+    :name,
+    :icon,
+    :splash,
+    :discovery_splash,
+    :emojis,
+    :features,
+    :approximate_member_count,
+    :approximate_presence_count,
+    :description
+  ]
+
+  @type t :: %__MODULE__{
+          id: Snowflake.t(),
+          name: String.t(),
+          icon: String.t() | nil,
+          splash: String.t() | nil,
+          discovery_splash: String.t() | nil,
+          emojis: [Emoji.t()],
+          features: [String.t()],
+          approximate_member_count: non_neg_integer(),
+          approximate_presence_count: non_neg_integer(),
+          description: String.t() | nil
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :id, &Snowflake.parse/1)
+    |> add_field(map, :name)
+    |> add_field(map, :icon)
+    |> add_field(map, :splash)
+    |> add_field(map, :discovery_splash)
+    |> add_field(map, :emojis, &parse_emojis/1)
+    |> add_field(map, :features)
+    |> add_field(map, :approximate_member_count)
+    |> add_field(map, :approximate_presence_count)
+    |> add_field(map, :description)
+  end
+
+  def parse(_), do: nil
+
+  defp parse_emojis(emojis), do: parse_list(emojis, &Emoji.parse/1)
+end

--- a/lib/mobius/models/voice_region.ex
+++ b/lib/mobius/models/voice_region.ex
@@ -1,0 +1,42 @@
+defmodule Mobius.Models.VoiceRegion do
+  @moduledoc """
+  Struct for Discord's Voice Region
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/voice#voice-region-object
+  """
+
+  import Mobius.Models.Utils
+
+  defstruct [
+    :id,
+    :name,
+    :vip,
+    :optimal,
+    :deprecated,
+    :custom
+  ]
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          name: String.t(),
+          vip: boolean,
+          optimal: boolean,
+          deprecated: boolean,
+          custom: boolean
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :id)
+    |> add_field(map, :name)
+    |> add_field(map, :vip)
+    |> add_field(map, :optimal)
+    |> add_field(map, :deprecated)
+    |> add_field(map, :custom)
+  end
+
+  def parse(_), do: nil
+end

--- a/test/mobius/models/ban_test.exs
+++ b/test/mobius/models/ban_test.exs
@@ -1,0 +1,38 @@
+defmodule Mobius.Models.BanTest do
+  use ExUnit.Case, async: true
+
+  import Mobius.Fixtures
+  import Mobius.Generators
+  import Mobius.TestUtils
+
+  alias Mobius.Models.Ban
+  alias Mobius.Models.User
+
+  describe "parse/1" do
+    test "returns nil for non-maps" do
+      assert nil == Ban.parse("string")
+      assert nil == Ban.parse(42)
+      assert nil == Ban.parse(true)
+      assert nil == Ban.parse(nil)
+    end
+
+    test "defaults to nil for all fields" do
+      %{}
+      |> Ban.parse()
+      |> assert_field(:reason, nil)
+      |> assert_field(:user, nil)
+    end
+
+    test "parses all fields as expected" do
+      map = %{
+        "reason" => random_hex(16),
+        "user" => user()
+      }
+
+      map
+      |> Ban.parse()
+      |> assert_field(:reason, map["reason"])
+      |> assert_field(:user, User.parse(map["user"]))
+    end
+  end
+end

--- a/test/mobius/models/guild_preview_test.exs
+++ b/test/mobius/models/guild_preview_test.exs
@@ -1,0 +1,64 @@
+defmodule Mobius.Models.GuildPreviewTest do
+  use ExUnit.Case, async: true
+
+  import Mobius.Fixtures
+  import Mobius.Generators
+  import Mobius.TestUtils
+
+  alias Mobius.Models.Emoji
+  alias Mobius.Models.GuildPreview
+  alias Mobius.Models.Snowflake
+  alias Mobius.Models.Utils
+
+  describe "parse/1" do
+    test "returns nil for non-maps" do
+      assert nil == GuildPreview.parse("string")
+      assert nil == GuildPreview.parse(42)
+      assert nil == GuildPreview.parse(true)
+      assert nil == GuildPreview.parse(nil)
+    end
+
+    test "defaults to nil for all fields" do
+      %{}
+      |> GuildPreview.parse()
+      |> assert_field(:id, nil)
+      |> assert_field(:name, nil)
+      |> assert_field(:icon, nil)
+      |> assert_field(:splash, nil)
+      |> assert_field(:discovery_splash, nil)
+      |> assert_field(:emojis, nil)
+      |> assert_field(:features, nil)
+      |> assert_field(:approximate_member_count, nil)
+      |> assert_field(:approximate_presence_count, nil)
+      |> assert_field(:description, nil)
+    end
+
+    test "parses all fields as expected" do
+      map = %{
+        "id" => random_snowflake(),
+        "name" => random_hex(8),
+        "icon" => random_hex(8),
+        "splash" => random_hex(16),
+        "discovery_splash" => random_hex(16),
+        "emojis" => [emoji()],
+        "features" => [random_hex(8)],
+        "approximate_member_count" => :rand.uniform(500_000),
+        "approximate_presence_count" => :rand.uniform(50_000),
+        "description" => random_hex(16)
+      }
+
+      map
+      |> GuildPreview.parse()
+      |> assert_field(:id, Snowflake.parse(map["id"]))
+      |> assert_field(:name, map["name"])
+      |> assert_field(:icon, map["icon"])
+      |> assert_field(:splash, map["splash"])
+      |> assert_field(:discovery_splash, map["discovery_splash"])
+      |> assert_field(:emojis, Utils.parse_list(map["emojis"], &Emoji.parse/1))
+      |> assert_field(:features, map["features"])
+      |> assert_field(:approximate_member_count, map["approximate_member_count"])
+      |> assert_field(:approximate_presence_count, map["approximate_presence_count"])
+      |> assert_field(:description, map["description"])
+    end
+  end
+end

--- a/test/mobius/models/voice_region_test.exs
+++ b/test/mobius/models/voice_region_test.exs
@@ -1,0 +1,48 @@
+defmodule Mobius.Models.VoiceRegionTest do
+  use ExUnit.Case, async: true
+
+  import Mobius.Fixtures
+  import Mobius.TestUtils
+
+  alias Mobius.Models.VoiceRegion
+
+  describe "parse/1" do
+    test "returns nil for non-maps" do
+      assert nil == VoiceRegion.parse("string")
+      assert nil == VoiceRegion.parse(42)
+      assert nil == VoiceRegion.parse(true)
+      assert nil == VoiceRegion.parse(nil)
+    end
+
+    test "defaults to nil for all fields" do
+      %{}
+      |> VoiceRegion.parse()
+      |> assert_field(:id, nil)
+      |> assert_field(:name, nil)
+      |> assert_field(:vip, nil)
+      |> assert_field(:optimal, nil)
+      |> assert_field(:deprecated, nil)
+      |> assert_field(:custom, nil)
+    end
+
+    test "parses all fields as expected" do
+      map = %{
+        "id" => random_hex(8),
+        "name" => random_hex(8),
+        "vip" => true,
+        "optimal" => true,
+        "deprecated" => false,
+        "custom" => false
+      }
+
+      map
+      |> VoiceRegion.parse()
+      |> assert_field(:id, map["id"])
+      |> assert_field(:name, map["name"])
+      |> assert_field(:vip, map["vip"])
+      |> assert_field(:optimal, map["optimal"])
+      |> assert_field(:deprecated, map["deprecated"])
+      |> assert_field(:custom, map["custom"])
+    end
+  end
+end


### PR DESCRIPTION
Same thing as #37 but for GuildPreview, Ban, and VoiceRegion

Just like #37, this is a part of #28 which was updated during development.