### PR TITLE
feat(models): Added VoiceState

### DIFF
--- a/lib/mobius/models/activity.ex
+++ b/lib/mobius/models/activity.ex
@@ -1,0 +1,91 @@
+defmodule Mobius.Models.Activity do
+  @moduledoc """
+  Struct for Discord's Activity
+
+  Related documentation:
+  https://discord.com/developers/docs/topics/gateway#activity-object
+  """
+
+  import Mobius.Models.Utils
+
+  alias Mobius.Models.Snowflake
+
+  defstruct [
+    :name,
+    :type,
+    :url,
+    :created_at,
+    :timestamps,
+    :application_id,
+    :details,
+    :state,
+    :emoji,
+    :party,
+    :assets,
+    :secrets,
+    :instance,
+    :flags
+  ]
+
+  @flags [
+    :instance,
+    :join,
+    :spectate,
+    :join_request,
+    :sync,
+    :play
+  ]
+
+  @type type :: :game | :streaming | :listening | :custom | :competing
+  @type flag :: :instance | :join | :spectate | :join_request | :sync | :play
+  @type flags :: MapSet.t(flag)
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          type: type(),
+          url: String.t(),
+          created_at: DateTime.t(),
+          timestamps: map,
+          application_id: Snowflake.t(),
+          details: String.t(),
+          state: String.t(),
+          emoji: map,
+          party: map,
+          assets: map,
+          secrets: map,
+          instance: boolean,
+          flags: flags()
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :name)
+    |> add_field(map, :type, &parse_type/1)
+    |> add_field(map, :url)
+    |> add_field(map, :created_at, &parse_timestamp/1)
+    |> add_field(map, :timestamps)
+    |> add_field(map, :application_id, &Snowflake.parse/1)
+    |> add_field(map, :details)
+    |> add_field(map, :state)
+    |> add_field(map, :emoji)
+    |> add_field(map, :party)
+    |> add_field(map, :assets)
+    |> add_field(map, :secrets)
+    |> add_field(map, :instance)
+    |> add_field(map, :flags, &parse_flags(&1, @flags))
+  end
+
+  def parse(_), do: nil
+
+  defp parse_timestamp(stamp) when is_integer(stamp), do: DateTime.from_unix!(stamp, :millisecond)
+  defp parse_timestamp(_), do: nil
+
+  defp parse_type(0), do: :game
+  defp parse_type(1), do: :streaming
+  defp parse_type(2), do: :listening
+  defp parse_type(4), do: :custom
+  defp parse_type(5), do: :competing
+  defp parse_type(_), do: nil
+end

--- a/lib/mobius/models/message.ex
+++ b/lib/mobius/models/message.ex
@@ -8,7 +8,6 @@ defmodule Mobius.Models.Message do
 
   import Mobius.Models.Utils
 
-  alias Mobius.Core.Bitflags
   alias Mobius.Models.Attachment
   alias Mobius.Models.ChannelMention
   alias Mobius.Models.Embed
@@ -142,7 +141,7 @@ defmodule Mobius.Models.Message do
     |> add_field(map, :activity, &MessageActivity.parse/1)
     |> add_field(map, :application, &MessageApplication.parse/1)
     |> add_field(map, :message_reference, &MessageReference.parse/1)
-    |> add_field(map, :flags, &parse_flags/1)
+    |> add_field(map, :flags, &parse_flags(&1, @flags))
     |> add_field(map, :stickers, &parse_stickers/1)
     |> add_field(map, :referenced_message, &parse/1)
   end
@@ -167,9 +166,6 @@ defmodule Mobius.Models.Message do
   defp parse_type(19), do: :reply
   defp parse_type(20), do: :application_command
   defp parse_type(_), do: nil
-
-  defp parse_flags(flags) when is_integer(flags), do: Bitflags.parse_bitflags(flags, @flags)
-  defp parse_flags(_flags), do: nil
 
   defp parse_stickers(stickers), do: parse_list(stickers, &Sticker.parse/1)
   defp parse_reactions(reactions), do: parse_list(reactions, &Reaction.parse/1)

--- a/lib/mobius/models/presence.ex
+++ b/lib/mobius/models/presence.ex
@@ -1,0 +1,57 @@
+defmodule Mobius.Models.Presence do
+  @moduledoc """
+  Struct for Discord's Presence
+
+  Related documentation:
+  https://discord.com/developers/docs/topics/gateway#presence-update
+  """
+
+  import Mobius.Models.Utils
+
+  alias Mobius.Models.Activity
+  alias Mobius.Models.Snowflake
+
+  defstruct [
+    :user_id,
+    :guild_id,
+    :status,
+    :activities,
+    :client_status
+  ]
+
+  @type status :: :idle | :dnd | :online | :offline
+
+  @type t :: %__MODULE__{
+          user_id: Snowflake.t(),
+          guild_id: Snowflake.t(),
+          status: status(),
+          activities: Activity.t(),
+          client_status: map
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{user_id: Snowflake.parse(map["user"]["id"])}
+    |> add_field(map, :guild_id, &Snowflake.parse/1)
+    |> add_field(map, :status, &parse_status/1)
+    |> add_field(map, :activities, &parse_activities/1)
+    |> add_field(map, :client_status, &parse_statuses/1)
+  end
+
+  def parse(_), do: nil
+
+  defp parse_status("idle"), do: :idle
+  defp parse_status("dnd"), do: :dnd
+  defp parse_status("online"), do: :online
+  defp parse_status("offline"), do: :offline
+  defp parse_status(_), do: nil
+
+  defp parse_activities(activities), do: parse_list(activities, &Activity.parse/1)
+
+  defp parse_statuses(statuses) when is_map(statuses) do
+    Map.new(statuses, fn {k, v} -> {k, parse_status(v)} end)
+  end
+
+  defp parse_statuses(_), do: nil
+end

--- a/lib/mobius/models/user.ex
+++ b/lib/mobius/models/user.ex
@@ -7,7 +7,6 @@ defmodule Mobius.Models.User do
 
   import Mobius.Models.Utils
 
-  alias Mobius.Core.Bitflags
   alias Mobius.Models.Snowflake
 
   defstruct [
@@ -101,9 +100,9 @@ defmodule Mobius.Models.User do
     |> add_field(map, :locale)
     |> add_field(map, :verified)
     |> add_field(map, :email)
-    |> add_field(map, :flags, &parse_flags/1)
+    |> add_field(map, :flags, &parse_flags(&1, @flags))
     |> add_field(map, :premium_type, &parse_premium_type/1)
-    |> add_field(map, :public_flags, &parse_flags/1)
+    |> add_field(map, :public_flags, &parse_flags(&1, @flags))
   end
 
   def parse(_), do: nil
@@ -112,7 +111,4 @@ defmodule Mobius.Models.User do
   defp parse_premium_type(1), do: :nitro_classic
   defp parse_premium_type(2), do: :nitro
   defp parse_premium_type(_), do: nil
-
-  defp parse_flags(flags) when is_integer(flags), do: Bitflags.parse_bitflags(flags, @flags)
-  defp parse_flags(_flags), do: nil
 end

--- a/lib/mobius/models/utils.ex
+++ b/lib/mobius/models/utils.ex
@@ -1,6 +1,8 @@
 defmodule Mobius.Models.Utils do
   @moduledoc false
 
+  alias Mobius.Core.Bitflags
+
   @doc """
   Adds a field to the struct with the value given by struct_key in the map
 
@@ -34,4 +36,7 @@ defmodule Mobius.Models.Utils do
   end
 
   def parse_integer(_value), do: nil
+
+  def parse_flags(value, flags) when is_integer(value), do: Bitflags.parse_bitflags(value, flags)
+  def parse_flags(_value, _flags), do: nil
 end

--- a/lib/mobius/models/voice_state.ex
+++ b/lib/mobius/models/voice_state.ex
@@ -1,0 +1,63 @@
+defmodule Mobius.Models.VoiceState do
+  @moduledoc """
+  Struct for Discord's Voice State
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/voice#voice-state-object
+  """
+
+  import Mobius.Models.Utils
+
+  alias Mobius.Models.Member
+  alias Mobius.Models.Snowflake
+
+  defstruct [
+    :guild_id,
+    :channel_id,
+    :user_id,
+    :member,
+    :session_id,
+    :deaf,
+    :mute,
+    :self_deaf,
+    :self_mute,
+    :self_stream,
+    :self_video,
+    :suppress
+  ]
+
+  @type t :: %__MODULE__{
+          guild_id: Snowflake.t() | nil,
+          channel_id: Snowflake.t() | nil,
+          user_id: Snowflake.t(),
+          member: Member.t() | nil,
+          session_id: String.t(),
+          deaf: boolean,
+          mute: boolean,
+          self_deaf: boolean,
+          self_mute: boolean,
+          self_stream: boolean | nil,
+          self_video: boolean,
+          suppress: boolean
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :guild_id, &Snowflake.parse/1)
+    |> add_field(map, :channel_id, &Snowflake.parse/1)
+    |> add_field(map, :user_id, &Snowflake.parse/1)
+    |> add_field(map, :member, &Member.parse/1)
+    |> add_field(map, :session_id)
+    |> add_field(map, :deaf)
+    |> add_field(map, :mute)
+    |> add_field(map, :self_deaf)
+    |> add_field(map, :self_mute)
+    |> add_field(map, :self_stream)
+    |> add_field(map, :self_video)
+    |> add_field(map, :suppress)
+  end
+
+  def parse(_), do: nil
+end

--- a/test/mobius/models/activity_test.exs
+++ b/test/mobius/models/activity_test.exs
@@ -1,0 +1,58 @@
+defmodule Mobius.Models.ActivityTest do
+  use ExUnit.Case, async: true
+
+  import Mobius.Generators
+  import Mobius.TestUtils
+
+  alias Mobius.Models.Activity
+  alias Mobius.Models.Snowflake
+
+  describe "parse/1" do
+    test "returns nil for non-maps" do
+      assert nil == Activity.parse("string")
+      assert nil == Activity.parse(42)
+      assert nil == Activity.parse(true)
+      assert nil == Activity.parse(nil)
+    end
+
+    test "defaults to nil for all fields" do
+      %{}
+      |> Activity.parse()
+      |> assert_field(:name, nil)
+      |> assert_field(:type, nil)
+      |> assert_field(:url, nil)
+      |> assert_field(:created_at, nil)
+      |> assert_field(:timestamps, nil)
+      |> assert_field(:application_id, nil)
+      |> assert_field(:details, nil)
+      |> assert_field(:state, nil)
+      |> assert_field(:emoji, nil)
+      |> assert_field(:party, nil)
+      |> assert_field(:assets, nil)
+      |> assert_field(:secrets, nil)
+      |> assert_field(:instance, nil)
+      |> assert_field(:flags, nil)
+    end
+
+    test "parses all fields as expected" do
+      map = activity()
+
+      map
+      |> Activity.parse()
+      |> assert_field(:name, map["name"])
+      |> assert_field(:type, :custom)
+      |> assert_field(:url, map["url"])
+      |> assert_field(:created_at, DateTime.from_unix!(map["created_at"], :millisecond))
+      |> assert_field(:timestamps, map["timestamps"])
+      |> assert_field(:application_id, Snowflake.parse(map["application_id"]))
+      |> assert_field(:details, map["details"])
+      |> assert_field(:state, map["state"])
+      |> assert_field(:emoji, map["emoji"])
+      |> assert_field(:party, map["party"])
+      |> assert_field(:assets, map["assets"])
+      |> assert_field(:secrets, map["secrets"])
+      |> assert_field(:instance, map["instance"])
+      |> assert_field(:flags, MapSet.new([:join, :spectate, :play]))
+    end
+  end
+end

--- a/test/mobius/models/presence_test.exs
+++ b/test/mobius/models/presence_test.exs
@@ -1,0 +1,46 @@
+defmodule Mobius.Models.PresenceTest do
+  use ExUnit.Case, async: true
+
+  import Mobius.Generators
+  import Mobius.TestUtils
+
+  alias Mobius.Models.Activity
+  alias Mobius.Models.Presence
+  alias Mobius.Models.Snowflake
+  alias Mobius.Models.Utils
+
+  describe "parse/1" do
+    test "returns nil for non-maps" do
+      assert nil == Presence.parse("string")
+      assert nil == Presence.parse(42)
+      assert nil == Presence.parse(true)
+      assert nil == Presence.parse(nil)
+    end
+
+    test "defaults to nil for all fields" do
+      %{}
+      |> Presence.parse()
+      |> assert_field(:user_id, nil)
+      |> assert_field(:guild_id, nil)
+      |> assert_field(:status, nil)
+      |> assert_field(:activities, nil)
+      |> assert_field(:client_status, nil)
+    end
+
+    test "parses all fields as expected" do
+      map = presence()
+
+      map
+      |> Presence.parse()
+      |> assert_field(:user_id, Snowflake.parse(map["user"]["id"]))
+      |> assert_field(:guild_id, Snowflake.parse(map["guild_id"]))
+      |> assert_field(:status, :online)
+      |> assert_field(:activities, Utils.parse_list(map["activities"], &Activity.parse/1))
+      |> assert_field(:client_status, %{
+        "desktop" => :idle,
+        "mobile" => :dnd,
+        "web" => :offline
+      })
+    end
+  end
+end

--- a/test/mobius/models/voice_state_test.exs
+++ b/test/mobius/models/voice_state_test.exs
@@ -1,0 +1,55 @@
+defmodule Mobius.Models.VoiceStateTest do
+  use ExUnit.Case, async: true
+
+  import Mobius.Generators
+  import Mobius.TestUtils
+
+  alias Mobius.Models.Member
+  alias Mobius.Models.Snowflake
+  alias Mobius.Models.VoiceState
+
+  describe "parse/1" do
+    test "returns nil for non-maps" do
+      assert nil == VoiceState.parse("string")
+      assert nil == VoiceState.parse(42)
+      assert nil == VoiceState.parse(true)
+      assert nil == VoiceState.parse(nil)
+    end
+
+    test "defaults to nil for all fields" do
+      %{}
+      |> VoiceState.parse()
+      |> assert_field(:guild_id, nil)
+      |> assert_field(:channel_id, nil)
+      |> assert_field(:user_id, nil)
+      |> assert_field(:member, nil)
+      |> assert_field(:session_id, nil)
+      |> assert_field(:deaf, nil)
+      |> assert_field(:mute, nil)
+      |> assert_field(:self_deaf, nil)
+      |> assert_field(:self_mute, nil)
+      |> assert_field(:self_stream, nil)
+      |> assert_field(:self_video, nil)
+      |> assert_field(:suppress, nil)
+    end
+
+    test "parses all fields as expected" do
+      map = voice_state()
+
+      map
+      |> VoiceState.parse()
+      |> assert_field(:guild_id, Snowflake.parse(map["guild_id"]))
+      |> assert_field(:channel_id, Snowflake.parse(map["channel_id"]))
+      |> assert_field(:user_id, Snowflake.parse(map["user_id"]))
+      |> assert_field(:member, Member.parse(map["member"]))
+      |> assert_field(:session_id, map["session_id"])
+      |> assert_field(:deaf, map["deaf"])
+      |> assert_field(:mute, map["mute"])
+      |> assert_field(:self_deaf, map["self_deaf"])
+      |> assert_field(:self_mute, map["self_mute"])
+      |> assert_field(:self_stream, map["self_stream"])
+      |> assert_field(:self_video, map["self_video"])
+      |> assert_field(:suppress, map["suppress"])
+    end
+  end
+end

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -236,6 +236,61 @@ defmodule Mobius.Generators do
     merge_opts(defaults, opts)
   end
 
+  @spec presence(keyword) :: map
+  def presence(opts \\ []) do
+    defaults = %{
+      "user" => partial_user(),
+      "guild_id" => random_snowflake(),
+      "status" => "online",
+      "activities" => [activity()],
+      "client_status" => %{
+        "desktop" => "idle",
+        "mobile" => "dnd",
+        "web" => "offline"
+      }
+    }
+
+    merge_opts(defaults, opts)
+  end
+
+  @spec activity(keyword) :: map
+  def activity(opts \\ []) do
+    defaults = %{
+      "name" => random_hex(8),
+      "type" => 4,
+      "url" => random_hex(16),
+      "created_at" => DateTime.to_unix(DateTime.utc_now(), :millisecond),
+      "timestamps" => %{
+        "start" => DateTime.to_unix(DateTime.utc_now(), :millisecond),
+        "end" => DateTime.to_unix(DateTime.utc_now(), :millisecond)
+      },
+      "application_id" => random_snowflake(),
+      "details" => random_hex(8),
+      "state" => random_hex(16),
+      "emoji" => %{
+        "name" => random_hex(8),
+        "id" => random_snowflake(),
+        "animated" => true
+      },
+      "party" => %{"id" => random_hex(8), "size" => [5, 10]},
+      "assets" => %{
+        "large_image" => random_hex(8),
+        "large_text" => random_hex(8),
+        "small_image" => random_hex(8),
+        "small_text" => random_hex(8)
+      },
+      "secrets" => %{
+        "join" => random_hex(32),
+        "spectate" => random_hex(32),
+        "match" => random_hex(32)
+      },
+      "instance" => true,
+      "flags" => 0b100110
+    }
+
+    merge_opts(defaults, opts)
+  end
+
   @spec application(keyword) :: map
   def application(opts \\ []) do
     team_id = random_snowflake()

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -98,6 +98,26 @@ defmodule Mobius.Generators do
     merge_opts(defaults, opts)
   end
 
+  @spec voice_state(keyword) :: map
+  def voice_state(opts \\ []) do
+    defaults = %{
+      "guild_id" => random_snowflake(),
+      "channel_id" => random_snowflake(),
+      "user_id" => random_snowflake(),
+      "member" => member(),
+      "session_id" => random_hex(16),
+      "deaf" => false,
+      "mute" => false,
+      "self_deaf" => true,
+      "self_mute" => true,
+      "self_stream" => true,
+      "self_video" => false,
+      "suppress" => false
+    }
+
+    merge_opts(defaults, opts)
+  end
+
   @spec member(keyword) :: map
   def member(opts \\ []) do
     defaults = %{


### PR DESCRIPTION
Same thing as #37 but for VoiceState and Presence (which includes Activity)

Presence (and Activity) included some pretty niche fields which would be very annoying to parse into individual structs so I've made the choice of keeping those as maps with strings as keys. If you disagree with this decision, do tell me.

Just like #37, this is a part of #28 which was updated during development.