### PR TITLE
feat(actions): Implementing send message

### DIFF
--- a/lib/mobius/actions/message.ex
+++ b/lib/mobius/actions/message.ex
@@ -5,7 +5,10 @@ defmodule Mobius.Actions.Message do
 
   alias Mobius.Models.Message
   alias Mobius.Rest
+  alias Mobius.Rest.Client
   alias Mobius.Services.Bot
+
+  @type message_body :: Rest.Message.message_body()
 
   @doc """
   Send a message in a channel
@@ -32,21 +35,22 @@ defmodule Mobius.Actions.Message do
   Relevant documentation:
   https://discord.com/developers/docs/resources/channel#create-message
   """
-  @spec send_message(keyword, Snowflake.t()) :: Rest.Client.result(Message.t())
-  def send_message(params, channel_id) do
+  @spec send_message(message_body(), Snowflake.t()) :: Client.result(Message.t())
+  def send_message(body, channel_id) do
     cond do
-      not Keyword.has_key?(params, :content) and not Keyword.has_key?(params, :embed) ->
+      not Map.has_key?(body, :content) and not Map.has_key?(body, :embed) ->
         {:error, "Must have at least one of content or embed when sending a message"}
 
-      String.length(Keyword.get(params, :content, "")) > 2000 ->
+      String.length(Map.get(body, :content, "")) > 2000 ->
         {:error, "Content is too long (maximum 2000 characters)"}
 
+      # TODO: Validate the embed limits (see https://discord.com/developers/docs/resources/channel#embed-limits)
       # TODO: Make sure the channel exists (requires a cache)
       # TODO: Make sure permissions are right (requires a cache)
       # TODO: Make sure the bot is connected to the gateway
 
       true ->
-        Rest.Message.send_message(Bot.get_client!(), channel_id, params)
+        Rest.Message.send_message(Bot.get_client!(), channel_id, body)
     end
   end
 end

--- a/lib/mobius/actions/message.ex
+++ b/lib/mobius/actions/message.ex
@@ -1,0 +1,46 @@
+defmodule Mobius.Actions.Message do
+  @moduledoc """
+  Actions related to Discord messages such as sending, editing, and deleting messages
+  """
+
+  alias Mobius.Models.Message
+  alias Mobius.Rest
+  alias Mobius.Services.Bot
+
+  @doc """
+  Send a message in a channel
+
+  The params can be:
+    - `content`: The message's content
+
+  ## Example
+
+      iex> send_message([content: "Some content", ], channel_id)
+
+  ## Documentation
+
+  Refer to the documentation for details on the limitations given by Discord.
+  This function is specifically for `content-type: application/json`.
+  See `send_file/3` for `content-type: multipart/form-data`.
+
+  Relevant documentation:
+  https://discord.com/developers/docs/resources/channel#create-message
+  """
+  @spec send_message(keyword, Snowflake.t()) :: Rest.Client.result(Message.t())
+  def send_message(params, channel_id) do
+    cond do
+      not Keyword.has_key?(params, :content) and not Keyword.has_key?(params, :embed) ->
+        {:error, "Must have at least one of content or embed when sending a message"}
+
+      String.length(Keyword.get(params, :content, "")) > 2000 ->
+        {:error, "Content is too long (maximum 2000 characters)"}
+
+      # TODO: Make sure the channel exists (requires a cache)
+      # TODO: Make sure permissions are right (requires a cache)
+      # TODO: Make sure the bot is connected to the gateway
+
+      true ->
+        Rest.Message.send_message(Bot.get_client!(), channel_id, params)
+    end
+  end
+end

--- a/lib/mobius/actions/message.ex
+++ b/lib/mobius/actions/message.ex
@@ -14,9 +14,9 @@ defmodule Mobius.Actions.Message do
     - `content`: The message's content (maximum 2000 chars)
     - `nonce`: random string or integer to compare with received messages and check its reception
     - `tts`: true if this message should be read with tts
-    - `embed`: an embed (with type `rich`) with some restrictions
-    - `allowed_mentions`: the mentions allowed in this message (see docs)
-    - `message_reference`: identifies the message being replied to (see docs)
+    - `embed`: an embed with type `rich` and some restrictions (see Discord docs)
+    - `allowed_mentions`: the mentions allowed in this message (see Discord docs)
+    - `message_reference`: identifies the message being replied to (see Discord docs)
 
   ## Example
 

--- a/lib/mobius/actions/message.ex
+++ b/lib/mobius/actions/message.ex
@@ -11,11 +11,17 @@ defmodule Mobius.Actions.Message do
   Send a message in a channel
 
   The params can be:
-    - `content`: The message's content
+    - `content`: The message's content (maximum 2000 chars)
+    - `nonce`: random string or integer to compare with received messages and check its reception
+    - `tts`: true if this message should be read with tts
+    - `embed`: an embed (with type `rich`) with some restrictions
+    - `allowed_mentions`: the mentions allowed in this message (see docs)
+    - `message_reference`: identifies the message being replied to (see docs)
 
   ## Example
 
-      iex> send_message([content: "Some content", ], channel_id)
+      iex> send_message([content: "Some content"], channel_id)
+      {:ok, %Mobius.Models.Message{} = message}
 
   ## Documentation
 

--- a/lib/mobius/rest/message.ex
+++ b/lib/mobius/rest/message.ex
@@ -1,0 +1,39 @@
+defmodule Mobius.Rest.Message do
+  @moduledoc false
+
+  alias Mobius.Models.Message
+  alias Mobius.Models.Snowflake
+  alias Mobius.Rest.Client
+
+  @doc """
+  Does the API call for "Create Message"'s with `content-type: application/json`
+
+  This doesn't allow sending files since allowing both in the same function would make it very
+  complicated with little added value. Instead sending files is implemented in `send_file/4`.
+  """
+  @spec send_message(Client.client(), Snowflake.t(), keyword) :: Client.result(Message.t())
+  def send_message(client, channel_id, params) do
+    body =
+      %{}
+      |> add_param(params, :content)
+      |> add_param(params, :nonce)
+      |> add_param(params, :tts)
+      |> add_param(params, :embed)
+      |> add_param(params, :allowed_mentions)
+      |> add_param(params, :message_reference)
+
+    client
+    |> Tesla.post("/channels/:channel_id/messages", body,
+      opts: [path_params: [channel_id: channel_id]]
+    )
+    |> Client.parse_response(&Message.parse/1)
+  end
+
+  defp add_param(map, params, field) do
+    if Keyword.has_key?(params, field) do
+      Map.put(map, field, Keyword.fetch!(params, field))
+    else
+      map
+    end
+  end
+end

--- a/lib/mobius/rest/message.ex
+++ b/lib/mobius/rest/message.ex
@@ -5,35 +5,64 @@ defmodule Mobius.Rest.Message do
   alias Mobius.Models.Snowflake
   alias Mobius.Rest.Client
 
+  @type embed :: %{
+          optional(:title) => String.t(),
+          optional(:description) => String.t(),
+          optional(:url) => String.t(),
+          optional(:timestamp) => DateTime.t(),
+          optional(:color) => 0..16_777_215,
+          optional(:footer) => %{optional(:text) => String.t(), optional(:icon_url) => String.t()},
+          optional(:image) => %{url: String.t()},
+          optional(:thumbnail) => %{url: String.t()},
+          optional(:author) => %{
+            optional(:name) => String.t(),
+            optional(:url) => String.t(),
+            optional(:icon_url) => String.t()
+          },
+          optional(:fields) => [
+            %{
+              required(:name) => String.t(),
+              required(:value) => String.t(),
+              optional(:inline) => boolean
+            }
+          ]
+        }
+
+  @type allowed_mentions :: %{
+          optional(:parse) => [:roles | :users | :everyone],
+          optional(:roles) => [Snowflake.t()],
+          optional(:users) => [Snowflake.t()],
+          optional(:replied_user) => boolean
+        }
+
+  @type message_reference :: %{
+          required(:message_id) => Snowflake.t(),
+          optional(:channel_id) => Snowflake.t(),
+          optional(:guild_id) => Snowflake.t(),
+          optional(:fail_if_not_exists) => boolean
+        }
+
+  @type message_body :: %{
+          content: String.t(),
+          nonce: String.t(),
+          tts: boolean,
+          embed: embed(),
+          allowed_mentions: allowed_mentions(),
+          message_reference: message_reference()
+        }
+
   @doc """
   Does the API call for "Create Message"'s with `content-type: application/json`
 
   This doesn't allow sending files since allowing both in the same function would make it very
   complicated with little added value. Instead sending files is implemented in `send_file/4`.
   """
-  @spec send_message(Client.client(), Snowflake.t(), keyword) :: Client.result(Message.t())
-  def send_message(client, channel_id, params) do
-    body =
-      %{}
-      |> add_param(params, :content)
-      |> add_param(params, :nonce)
-      |> add_param(params, :tts)
-      |> add_param(params, :embed)
-      |> add_param(params, :allowed_mentions)
-      |> add_param(params, :message_reference)
-
+  @spec send_message(Client.client(), Snowflake.t(), message_body()) :: Client.result(Message.t())
+  def send_message(client, channel_id, body) do
     client
     |> Tesla.post("/channels/:channel_id/messages", body,
       opts: [path_params: [channel_id: channel_id]]
     )
     |> Client.parse_response(&Message.parse/1)
-  end
-
-  defp add_param(map, params, field) do
-    if Keyword.has_key?(params, field) do
-      Map.put(map, field, Keyword.fetch!(params, field))
-    else
-      map
-    end
   end
 end

--- a/test/mobius/actions/message_test.exs
+++ b/test/mobius/actions/message_test.exs
@@ -26,17 +26,17 @@ defmodule Mobius.Actions.MessageTest do
     end
 
     test "returns an error if neither content or embed is given", ctx do
-      {:error, error} = Message.send_message([], ctx.channel_id)
+      {:error, error} = Message.send_message(%{}, ctx.channel_id)
       assert error =~ "at least one of content or embed"
     end
 
     test "returns an error if content is longer than 2000 chars", ctx do
-      {:error, error} = Message.send_message([content: random_hex(2001)], ctx.channel_id)
+      {:error, error} = Message.send_message(%{content: random_hex(2001)}, ctx.channel_id)
       assert error =~ "Content is too long"
     end
 
     test "returns the message if successful", ctx do
-      {:ok, message} = Message.send_message([content: random_hex(2000)], ctx.channel_id)
+      {:ok, message} = Message.send_message(%{content: random_hex(2000)}, ctx.channel_id)
       assert message == Models.Message.parse(ctx.raw_message)
     end
   end

--- a/test/mobius/actions/message_test.exs
+++ b/test/mobius/actions/message_test.exs
@@ -1,0 +1,43 @@
+defmodule Mobius.Actions.MessageTest do
+  use ExUnit.Case
+
+  import Mobius.Fixtures
+  import Mobius.Generators
+  import Tesla.Mock, only: [mock: 1]
+
+  alias Mobius.Actions.Message
+  alias Mobius.Models
+  alias Mobius.Rest.Client
+
+  setup :reset_services
+  setup :create_rest_client
+  setup :stub_socket
+  setup :stub_ratelimiter
+  setup :get_shard
+  setup :handshake_shard
+
+  describe "send_message/2" do
+    setup do
+      channel_id = random_snowflake()
+      raw = message(channel_id: channel_id)
+      url = Client.base_url() <> "/channels/#{channel_id}/messages"
+      mock(fn %{method: :post, url: ^url} -> json(raw) end)
+      [channel_id: channel_id, raw_message: raw]
+    end
+
+    test "returns an error if neither content or embed is given", ctx do
+      {:error, error} = Message.send_message([], ctx.channel_id)
+      assert error =~ "at least one of content or embed"
+    end
+
+    test "returns an error if content is longer than 2000 chars", ctx do
+      {:error, error} = Message.send_message([content: random_hex(2001)], ctx.channel_id)
+      assert error =~ "Content is too long"
+    end
+
+    test "returns the message if successful", ctx do
+      {:ok, message} = Message.send_message([content: random_hex(2000)], ctx.channel_id)
+      assert message == Models.Message.parse(ctx.raw_message)
+    end
+  end
+end

--- a/test/mobius/actions/status_test.exs
+++ b/test/mobius/actions/status_test.exs
@@ -26,25 +26,25 @@ defmodule Mobius.Actions.StatusTest do
       payload = Opcode.update_status(status)
       assert_receive {:socket_msg, ^payload}
     end
-  end
 
-  test "asks ratelimiter about update_status ratelimit", ctx do
-    Status.change_status(BotStatus.new())
+    test "asks ratelimiter about update_status ratelimit", ctx do
+      Status.change_status(BotStatus.new())
 
-    expected_bucket = {"shard:#{ctx.shard.number}:update_status", 60_000, 5}
-    assert_receive {:ratelimit_requested, ^expected_bucket}
-  end
+      expected_bucket = {"shard:#{ctx.shard.number}:update_status", 60_000, 5}
+      assert_receive {:ratelimit_requested, ^expected_bucket}
+    end
 
-  test "asks ratelimiter about global ratelimit", ctx do
-    Status.change_status(BotStatus.new())
+    test "asks ratelimiter about global ratelimit", ctx do
+      Status.change_status(BotStatus.new())
 
-    expected_bucket = {"shard:#{ctx.shard.number}:global", 60_000, 115}
-    assert_receive {:ratelimit_requested, ^expected_bucket}
-  end
+      expected_bucket = {"shard:#{ctx.shard.number}:global", 60_000, 115}
+      assert_receive {:ratelimit_requested, ^expected_bucket}
+    end
 
-  test "returns :ratelimited if ratelimited" do
-    CommandsRatelimiter.set_ratelimited(true)
+    test "returns :ratelimited if ratelimited" do
+      CommandsRatelimiter.set_ratelimited(true)
 
-    assert [{:error, :ratelimited}] == Status.change_status(BotStatus.new())
+      assert [{:error, :ratelimited}] == Status.change_status(BotStatus.new())
+    end
   end
 end

--- a/test/mobius/rest/client_test.exs
+++ b/test/mobius/rest/client_test.exs
@@ -6,7 +6,6 @@ defmodule Mobius.Rest.ClientTest do
 
   alias Mobius.Rest.Client
 
-  setup :create_token
   setup :create_rest_client
 
   describe "parse_response/2" do
@@ -133,9 +132,11 @@ defmodule Mobius.Rest.ClientTest do
       Tesla.get(ctx.client, ctx.url)
       assert_received :called_api
 
-      [{:token, token}] = create_token(%{})
-      [{:client, client}] = create_rest_client(%{token: token})
-      Tesla.get(client, ctx.url)
+      ctx
+      |> create_rest_client()
+      |> Keyword.fetch!(:client)
+      |> Tesla.get(ctx.url)
+
       assert_received :called_api
     end
   end

--- a/test/mobius/rest/gateway_test.exs
+++ b/test/mobius/rest/gateway_test.exs
@@ -8,7 +8,6 @@ defmodule Mobius.Rest.GatewayTest do
   alias Mobius.Rest
   alias Mobius.Rest.Client
 
-  setup :create_token
   setup :create_rest_client
 
   describe "get_bot/1" do

--- a/test/mobius/rest/message_test.exs
+++ b/test/mobius/rest/message_test.exs
@@ -1,0 +1,36 @@
+defmodule Mobius.Rest.MessageTest do
+  use ExUnit.Case, async: true
+
+  import Tesla.Mock, only: [mock: 1]
+  import Mobius.Fixtures
+  import Mobius.Generators
+
+  alias Mobius.Models
+  alias Mobius.Rest
+  alias Mobius.Rest.Client
+
+  setup :create_rest_client
+
+  describe "send_message/3" do
+    test "returns {:ok, Message.t()} if status is 200", ctx do
+      params = [
+        content: random_hex(32),
+        nonce: random_hex(8),
+        tts: true,
+        embed: embed(),
+        allowed_mentions: %{},
+        message_reference: %{message_id: random_snowflake()}
+      ]
+
+      channel_id = random_snowflake()
+      raw = message(channel_id: channel_id)
+      json_body = params |> Map.new() |> Jason.encode!()
+
+      url = Client.base_url() <> "/channels/#{channel_id}/messages"
+      mock(fn %{method: :post, url: ^url, body: ^json_body} -> json(raw) end)
+
+      assert {:ok, Models.Message.parse(raw)} ==
+               Rest.Message.send_message(ctx.client, channel_id, params)
+    end
+  end
+end

--- a/test/mobius/rest/message_test.exs
+++ b/test/mobius/rest/message_test.exs
@@ -13,24 +13,24 @@ defmodule Mobius.Rest.MessageTest do
 
   describe "send_message/3" do
     test "returns {:ok, Message.t()} if status is 200", ctx do
-      params = [
+      body = %{
         content: random_hex(32),
         nonce: random_hex(8),
         tts: true,
         embed: embed(),
         allowed_mentions: %{},
         message_reference: %{message_id: random_snowflake()}
-      ]
+      }
 
       channel_id = random_snowflake()
       raw = message(channel_id: channel_id)
-      json_body = params |> Map.new() |> Jason.encode!()
+      json_body = Jason.encode!(body)
 
       url = Client.base_url() <> "/channels/#{channel_id}/messages"
       mock(fn %{method: :post, url: ^url, body: ^json_body} -> json(raw) end)
 
       assert {:ok, Models.Message.parse(raw)} ==
-               Rest.Message.send_message(ctx.client, channel_id, params)
+               Rest.Message.send_message(ctx.client, channel_id, body)
     end
   end
 end

--- a/test/mobius/services/commands_ratelimiter/self_refill_test.exs
+++ b/test/mobius/services/commands_ratelimiter/self_refill_test.exs
@@ -9,7 +9,7 @@ defmodule Mobius.Services.CommandsRatelimiter.SelfRefillTest do
     # Manually start the service because it won't be started during tests
     start_supervised!({SelfRefill, []})
     # Generate a random bucket name so they don't overlap during tests
-    [bucket: random_hex(8)]
+    [bucket: random_hex(16)]
   end
 
   describe "request_access/1" do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -51,12 +51,9 @@ defmodule Mobius.Fixtures do
     [session_id: session_id, token: @token]
   end
 
-  def create_token(_context) do
-    [token: random_hex(8)]
-  end
-
-  def create_rest_client(context) do
-    [client: Client.new(token: context.token, max_retries: 0)]
+  def create_rest_client(_context) do
+    token = random_hex(8)
+    [token: token, client: Client.new(token: token, max_retries: 0)]
   end
 
   # Utility functions


### PR DESCRIPTION
Adds the `send_message` action. A future PR will add `send_file`

It also includes a little bit of refactoring (moving tests in status_test.exs into the describe; removing `create_token` from fixtures) and fixing tests (self_refill_test.exs somehow broke on me even though there's a one in 16^8 chance that the same bucket is used; I don't know whether that's really what happened, but 🤷)

This PR is a part of #29 