### PR TITLE
feat(cogs): Added an api for receiving the context

### DIFF
--- a/lib/mobius/cogs/ping_pong.ex
+++ b/lib/mobius/cogs/ping_pong.ex
@@ -3,7 +3,9 @@ defmodule Mobius.Cogs.PingPong do
 
   use Mobius.Cog
 
-  require Logger
+  import Mobius.Actions.Message
 
-  command "ping", do: Logger.info("pong")
+  command "ping", context do
+    send_message(%{content: "Pong!"}, context["channel_id"])
+  end
 end

--- a/lib/mobius/rest/message.ex
+++ b/lib/mobius/rest/message.ex
@@ -42,13 +42,14 @@ defmodule Mobius.Rest.Message do
           optional(:fail_if_not_exists) => boolean
         }
 
+  @typedoc "Both `:content` and `:embed` are optional, but at least one of the two must be given"
   @type message_body :: %{
-          content: String.t(),
-          nonce: String.t(),
-          tts: boolean,
-          embed: embed(),
-          allowed_mentions: allowed_mentions(),
-          message_reference: message_reference()
+          optional(:content) => String.t(),
+          optional(:nonce) => String.t(),
+          optional(:tts) => boolean,
+          optional(:embed) => embed(),
+          optional(:allowed_mentions) => allowed_mentions(),
+          optional(:message_reference) => message_reference()
         }
 
   @doc """

--- a/test/mobius/cog_test.exs
+++ b/test/mobius/cog_test.exs
@@ -24,7 +24,21 @@ defmodule Mobius.CogTest do
     end
   end
 
+  describe "command/2" do
+    test "should be called when a message starting with command name is received" do
+      send_message_payload("nothing")
+
+      assert_receive :nothing
+    end
+  end
+
   describe "command/3" do
+    test "should be called with the proper context if only a context is expected" do
+      message = send_message_payload("send")
+
+      assert_receive ^message
+    end
+
     test "should be called when messages starting with command name are received" do
       send_message_payload("reply hello")
 
@@ -51,6 +65,14 @@ defmodule Mobius.CogTest do
                Process.sleep(10)
              end) =~
                ~s'Invalid type for argument "num2". Expected "integer", got "hello".'
+    end
+  end
+
+  describe "command/4" do
+    test "should be called with the context and the parsed arguments" do
+      message = send_message_payload("everything 123")
+
+      assert_receive {:everything, ^message, 123}
     end
   end
 end

--- a/test/support/cog_stub.ex
+++ b/test/support/cog_stub.ex
@@ -7,12 +7,24 @@ defmodule Mobius.Stubs.Cog do
     send_to_test(content)
   end
 
+  command "nothing" do
+    send_to_test(:nothing)
+  end
+
+  command "send", context do
+    send_to_test(context)
+  end
+
   command "reply", message: :string do
     send_to_test(message)
   end
 
   command "add", num1: :integer, num2: :integer do
     send_to_test(num1 + num2)
+  end
+
+  command "everything", context, value: :integer do
+    send_to_test({:everything, context, value})
   end
 
   defp send_to_test(message) do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -122,10 +122,14 @@ defmodule Mobius.Fixtures do
   end
 
   def send_message_payload(content) do
+    message = %{"content" => content}
+
     send_payload(
       op: :dispatch,
       type: "MESSAGE_CREATE",
-      data: %{"content" => content}
+      data: message
     )
+
+    message
   end
 end


### PR DESCRIPTION
Closes #61

I ended up going with a different api from what was originally intended in the issue because it involved less code changes and was closer to other things like `ExUnit.Case.test/3`

The docs were updated to include plenty of examples and `Mobius.Cog.PingPong` was updated to make use of the context