### PR TITLE
feat(models): Added Webhook and Template

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           elixir-version: 1.10.4
           otp-version: 23.1

--- a/lib/mobius/models/guild_template.ex
+++ b/lib/mobius/models/guild_template.ex
@@ -1,0 +1,62 @@
+defmodule Mobius.Models.GuildTemplate do
+  @moduledoc """
+  Struct for Discord's Template
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/template#template-object
+  """
+
+  import Mobius.Models.Utils
+
+  alias Mobius.Models.Guild
+  alias Mobius.Models.Snowflake
+  alias Mobius.Models.Timestamp
+  alias Mobius.Models.User
+
+  defstruct [
+    :code,
+    :name,
+    :description,
+    :usage_count,
+    :creator_id,
+    :creator,
+    :created_at,
+    :updated_at,
+    :source_guild_id,
+    :serialized_source_guild,
+    :is_dirty
+  ]
+
+  @type t :: %__MODULE__{
+          code: String.t(),
+          name: String.t(),
+          description: String.t() | nil,
+          usage_count: non_neg_integer(),
+          creator_id: Snowflake.t(),
+          creator: User.t(),
+          created_at: DateTime.t(),
+          updated_at: DateTime.t(),
+          source_guild_id: Snowflake.t(),
+          serialized_source_guild: Guild.t(),
+          is_dirty: boolean | nil
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :code)
+    |> add_field(map, :name)
+    |> add_field(map, :description)
+    |> add_field(map, :usage_count)
+    |> add_field(map, :creator_id, &Snowflake.parse/1)
+    |> add_field(map, :creator, &User.parse/1)
+    |> add_field(map, :created_at, &Timestamp.parse/1)
+    |> add_field(map, :updated_at, &Timestamp.parse/1)
+    |> add_field(map, :source_guild_id, &Snowflake.parse/1)
+    |> add_field(map, :serialized_source_guild, &Guild.parse/1)
+    |> add_field(map, :is_dirty)
+  end
+
+  def parse(_), do: nil
+end

--- a/lib/mobius/models/webhook.ex
+++ b/lib/mobius/models/webhook.ex
@@ -1,0 +1,60 @@
+defmodule Mobius.Models.Webhook do
+  @moduledoc """
+  Struct for Discord's Webhook
+
+  Related documentation:
+  https://discord.com/developers/docs/resources/webhook#webhook-object
+  """
+
+  import Mobius.Models.Utils
+
+  alias Mobius.Models.Snowflake
+  alias Mobius.Models.User
+
+  defstruct [
+    :id,
+    :type,
+    :guild_id,
+    :channel_id,
+    :user,
+    :name,
+    :avatar,
+    :token,
+    :application_id
+  ]
+
+  @type type :: :incoming | :channel_follower
+
+  @type t :: %__MODULE__{
+          id: Snowflake.t(),
+          type: type(),
+          guild_id: Snowflake.t() | nil,
+          channel_id: Snowflake.t(),
+          user: User.t() | nil,
+          name: String.t() | nil,
+          avatar: String.t() | nil,
+          token: String.t() | nil,
+          application_id: Snowflake.t() | nil
+        }
+
+  @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @spec parse(any) :: t() | nil
+  def parse(map) when is_map(map) do
+    %__MODULE__{}
+    |> add_field(map, :id, &Snowflake.parse/1)
+    |> add_field(map, :type, &parse_type/1)
+    |> add_field(map, :guild_id, &Snowflake.parse/1)
+    |> add_field(map, :channel_id, &Snowflake.parse/1)
+    |> add_field(map, :user, &User.parse/1)
+    |> add_field(map, :name)
+    |> add_field(map, :avatar)
+    |> add_field(map, :token)
+    |> add_field(map, :application_id, &Snowflake.parse/1)
+  end
+
+  def parse(_), do: nil
+
+  defp parse_type(1), do: :incoming
+  defp parse_type(2), do: :channel_follower
+  defp parse_type(_), do: nil
+end

--- a/test/mobius/models/guild_template_test.exs
+++ b/test/mobius/models/guild_template_test.exs
@@ -1,0 +1,68 @@
+defmodule Mobius.Models.GuildTemplateTest do
+  use ExUnit.Case, async: true
+
+  import Mobius.Fixtures
+  import Mobius.Generators
+  import Mobius.TestUtils
+
+  alias Mobius.Models.Guild
+  alias Mobius.Models.GuildTemplate
+  alias Mobius.Models.Snowflake
+  alias Mobius.Models.Timestamp
+  alias Mobius.Models.User
+
+  describe "parse/1" do
+    test "returns nil for non-maps" do
+      assert nil == GuildTemplate.parse("string")
+      assert nil == GuildTemplate.parse(42)
+      assert nil == GuildTemplate.parse(true)
+      assert nil == GuildTemplate.parse(nil)
+    end
+
+    test "defaults to nil for all fields" do
+      %{}
+      |> GuildTemplate.parse()
+      |> assert_field(:code, nil)
+      |> assert_field(:name, nil)
+      |> assert_field(:description, nil)
+      |> assert_field(:usage_count, nil)
+      |> assert_field(:creator_id, nil)
+      |> assert_field(:creator, nil)
+      |> assert_field(:created_at, nil)
+      |> assert_field(:updated_at, nil)
+      |> assert_field(:source_guild_id, nil)
+      |> assert_field(:serialized_source_guild, nil)
+      |> assert_field(:is_dirty, nil)
+    end
+
+    test "parses all fields as expected" do
+      map = %{
+        "code" => random_hex(8),
+        "name" => random_hex(16),
+        "description" => random_hex(32),
+        "usage_count" => :rand.uniform(256),
+        "creator_id" => random_snowflake(),
+        "creator" => user(),
+        "created_at" => DateTime.to_iso8601(DateTime.utc_now()),
+        "updated_at" => DateTime.to_iso8601(DateTime.utc_now()),
+        "source_guild_id" => random_snowflake(),
+        "serialized_source_guild" => guild(),
+        "is_dirty" => false
+      }
+
+      map
+      |> GuildTemplate.parse()
+      |> assert_field(:code, map["code"])
+      |> assert_field(:name, map["name"])
+      |> assert_field(:description, map["description"])
+      |> assert_field(:usage_count, map["usage_count"])
+      |> assert_field(:creator_id, Snowflake.parse(map["creator_id"]))
+      |> assert_field(:creator, User.parse(map["creator"]))
+      |> assert_field(:created_at, Timestamp.parse(map["created_at"]))
+      |> assert_field(:updated_at, Timestamp.parse(map["updated_at"]))
+      |> assert_field(:source_guild_id, Snowflake.parse(map["source_guild_id"]))
+      |> assert_field(:serialized_source_guild, Guild.parse(map["serialized_source_guild"]))
+      |> assert_field(:is_dirty, map["is_dirty"])
+    end
+  end
+end

--- a/test/mobius/models/webhook_test.exs
+++ b/test/mobius/models/webhook_test.exs
@@ -1,0 +1,60 @@
+defmodule Mobius.Models.WebhookTest do
+  use ExUnit.Case, async: true
+
+  import Mobius.Fixtures
+  import Mobius.Generators
+  import Mobius.TestUtils
+
+  alias Mobius.Models.Snowflake
+  alias Mobius.Models.User
+  alias Mobius.Models.Webhook
+
+  describe "parse/1" do
+    test "returns nil for non-maps" do
+      assert nil == Webhook.parse("string")
+      assert nil == Webhook.parse(42)
+      assert nil == Webhook.parse(true)
+      assert nil == Webhook.parse(nil)
+    end
+
+    test "defaults to nil for all fields" do
+      %{}
+      |> Webhook.parse()
+      |> assert_field(:id, nil)
+      |> assert_field(:type, nil)
+      |> assert_field(:guild_id, nil)
+      |> assert_field(:channel_id, nil)
+      |> assert_field(:user, nil)
+      |> assert_field(:name, nil)
+      |> assert_field(:avatar, nil)
+      |> assert_field(:token, nil)
+      |> assert_field(:application_id, nil)
+    end
+
+    test "parses all fields as expected" do
+      map = %{
+        "id" => random_snowflake(),
+        "type" => 1,
+        "guild_id" => random_snowflake(),
+        "channel_id" => random_snowflake(),
+        "user" => user(),
+        "name" => random_hex(8),
+        "avatar" => random_hex(32),
+        "token" => random_hex(32),
+        "application_id" => random_snowflake()
+      }
+
+      map
+      |> Webhook.parse()
+      |> assert_field(:id, Snowflake.parse(map["id"]))
+      |> assert_field(:type, :incoming)
+      |> assert_field(:guild_id, Snowflake.parse(map["guild_id"]))
+      |> assert_field(:channel_id, Snowflake.parse(map["channel_id"]))
+      |> assert_field(:user, User.parse(map["user"]))
+      |> assert_field(:name, map["name"])
+      |> assert_field(:avatar, map["avatar"])
+      |> assert_field(:token, map["token"])
+      |> assert_field(:application_id, Snowflake.parse(map["application_id"]))
+    end
+  end
+end


### PR DESCRIPTION
Same thing as #37 but for Webhook and Guild Templates

Just like #37, this is a part of #28 which was updated during development.

**Also includes** a fix of github actions using a deprecated `setup-elixir`