### PR TITLE
feat: Added the global command prefix

### DIFF
--- a/lib/mobius/cog.ex
+++ b/lib/mobius/cog.ex
@@ -79,9 +79,10 @@ defmodule Mobius.Cog do
     quote location: :keep do
       use GenServer
       alias Mobius.Actions.Events
+      alias Mobius.Services.Bot
 
       listen :message_create, message do
-        case Command.execute_command(@commands, message) do
+        case Command.execute_command(@commands, Bot.get_global_prefix!(), message) do
           {:ok, _} ->
             :ok
 

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -34,10 +34,12 @@ defmodule Mobius.Core.Command do
   @spec arg_count(t()) :: non_neg_integer()
   def arg_count(%__MODULE__{} = command), do: length(command.args)
 
-  @spec execute_command([t()], Message.t()) :: handle_message_result()
-  def execute_command(commands, %{"content" => content} = message) do
+  @spec execute_command([t()], String.t(), Message.t()) :: handle_message_result()
+  def execute_command(commands, prefix, %{"content" => content} = message) do
     commands
-    |> Enum.find(fn %__MODULE__{} = command -> String.starts_with?(content, command.name) end)
+    |> Enum.find(fn %__MODULE__{} = command ->
+      String.starts_with?(content, prefix <> command.name)
+    end)
     |> case do
       nil ->
         :not_a_command

--- a/lib/mobius/services/bot.ex
+++ b/lib/mobius/services/bot.ex
@@ -60,6 +60,20 @@ defmodule Mobius.Services.Bot do
   end
 
   @doc """
+  Returns the current global command prefix of the bot
+
+  This command prefix is the default prefix for guilds which didn't set one
+  and for commands sent to the bot in private messages.
+
+  This may raise a `KeyError` if this service isn't started yet
+  """
+  def get_global_prefix! do
+    __MODULE__
+    |> :persistent_term.get(%{})
+    |> Map.fetch!(:global_prefix)
+  end
+
+  @doc """
   Notifies Bot about the shard being ready
 
   This function is meant for internal use by the shards and nothing else
@@ -82,7 +96,11 @@ defmodule Mobius.Services.Bot do
     # Both are regrouped in one term as recommended in the :persistent_term's best practices:
     # > Prefer creating a few large persistent terms to creating many small persistent terms
     # https://erlang.org/doc/man/persistent_term.html#best-practices-for-using-persistent-terms
-    :persistent_term.put(__MODULE__, %{client: client, intents: intents})
+    :persistent_term.put(__MODULE__, %{
+      client: client,
+      intents: intents,
+      global_prefix: "!"
+    })
 
     client
     |> start_shards(token, intents)

--- a/test/mobius/cog_test.exs
+++ b/test/mobius/cog_test.exs
@@ -26,7 +26,7 @@ defmodule Mobius.CogTest do
 
   describe "command/2" do
     test "should be called when a message starting with command name is received" do
-      send_message_payload("nothing")
+      send_command_payload("nothing")
 
       assert_receive :nothing
     end
@@ -44,26 +44,26 @@ defmodule Mobius.CogTest do
 
   describe "command/3" do
     test "should be called with the proper context if only a context is expected" do
-      message = send_message_payload("send")
+      message = send_command_payload("send")
 
       assert_receive ^message
     end
 
     test "should be called when messages starting with command name are received" do
-      send_message_payload("reply hello")
+      send_command_payload("reply hello")
 
       assert_receive "hello"
     end
 
     test "should parse integer arguments" do
-      send_message_payload("add 1 2")
+      send_command_payload("add 1 2")
 
       assert_receive 3
     end
 
     test "should notify of missing arguments" do
       assert capture_log(fn ->
-               send_message_payload("add 1")
+               send_command_payload("add 1")
                Process.sleep(10)
              end) =~
                "Too few arguments for command \"add\". Expected 2 arguments, got 1."
@@ -71,7 +71,7 @@ defmodule Mobius.CogTest do
 
     test "should notify of invalid arguments" do
       assert capture_log(fn ->
-               send_message_payload("add 2 hello")
+               send_command_payload("add 2 hello")
                Process.sleep(10)
              end) =~
                ~s'Invalid type for argument "num2". Expected "integer", got "hello".'
@@ -80,7 +80,7 @@ defmodule Mobius.CogTest do
 
   describe "command/4" do
     test "should be called with the context and the parsed arguments" do
-      message = send_message_payload("everything 123")
+      message = send_command_payload("everything 123")
 
       assert_receive {:everything, ^message, 123}
     end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -7,6 +7,7 @@ defmodule Mobius.Fixtures do
   alias Mobius.Core.Opcode
   alias Mobius.Core.ShardInfo
   alias Mobius.Rest.Client
+  alias Mobius.Services.Bot
   alias Mobius.Services.Socket
   alias Mobius.Stubs
 
@@ -123,6 +124,11 @@ defmodule Mobius.Fixtures do
 
   def empty_response do
     {204, [], nil}
+  end
+
+  def send_command_payload(content) do
+    prefix = Bot.get_global_prefix!()
+    send_message_payload(prefix <> content)
   end
 
   def send_message_payload(content) do


### PR DESCRIPTION
Closes #75 

A later PR could implement guild-specific prefixes, but that's not a requirement for v1