### PR TITLE
feat: Added Help cog

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Setup Elixir
         uses: erlef/setup-elixir@v1
         with:
-          elixir-version: 1.10.4
-          otp-version: 23.1
+          elixir-version: 1.12.1
+          otp-version: 24.0
       - name: Retrieve mix dependencies cache
         uses: actions/cache@v2
         id: mix-cache # id to use in retrieve action

--- a/lib/mobius/cog.ex
+++ b/lib/mobius/cog.ex
@@ -105,9 +105,7 @@ defmodule Mobius.Cog do
 
           {:too_few_args, arities, received} ->
             Logger.info(
-              "Wrong number of arguments. Expected one of #{
-                arities |> Enum.map(&Integer.to_string/1) |> Enum.join(", ")
-              } arguments, got #{received}."
+              "Wrong number of arguments. Expected one of #{arities |> Enum.map(&Integer.to_string/1) |> Enum.join(", ")} arguments, got #{received}."
             )
 
           {:invalid_args, [clause | _clauses]} ->

--- a/lib/mobius/cog_utils.ex
+++ b/lib/mobius/cog_utils.ex
@@ -3,7 +3,9 @@ defmodule Mobius.CogUtils do
   A module of utilities for cogs such as formatting tables
   """
 
-  @type categories :: [{String.t(), [{String.t(), String.t()}]}]
+  @type category_entry :: {String.t(), String.t()}
+  @type category :: {String.t(), [category_entry()]}
+  @type categories :: [category()]
 
   @doc ~S"""
   Formats a list of tuples such that the spacing aligns the 2nd element of the inner tuple
@@ -12,14 +14,26 @@ defmodule Mobius.CogUtils do
 
       iex> data = [{"Cat1", [{"abc", "description"}, {"defghi", "something"}]}]
       iex> format_categories_list(data)
-      "Cat1:\n  abc       description\n  defghi    something"
+      ~S"
+      Cat1:
+        abc       description
+        defghi    something
+      " |> String.trim()
 
       iex> data = [{"Cat1", [{"abc", "description"}]}, {"Cat2", [{"defghi", "something"}]}]
       iex> format_categories_list(data)
-      "Cat1:\n  abc       description\nCat2:\n  defghi    something"
+      ~S"
+      Cat1:
+        abc       description
+      Cat2:
+        defghi    something
+      " |> String.trim()
 
       iex> format_categories_list([{"Cat1", []}], "empty category")
-      "Cat1:\n  empty category"
+      ~S"
+      Cat1:
+        empty category
+      " |> String.trim()
 
       iex> format_categories_list([])
       ""

--- a/lib/mobius/cog_utils.ex
+++ b/lib/mobius/cog_utils.ex
@@ -1,0 +1,50 @@
+defmodule Mobius.CogUtils do
+  @moduledoc """
+  A module of utilities for cogs such as formatting tables
+  """
+
+  @type categories :: [{String.t(), [{String.t(), String.t()}]}]
+
+  @doc ~S"""
+  Formats a list of tuples such that the spacing aligns the 2nd element of the inner tuple
+
+  ## Example
+
+      iex> data = [{"Cat1", [{"abc", "description"}, {"defghi", "something"}]}]
+      iex> format_categories_list(data)
+      "Cat1:\n  abc       description\n  defghi    something"
+
+      iex> data = [{"Cat1", [{"abc", "description"}]}, {"Cat2", [{"defghi", "something"}]}]
+      iex> format_categories_list(data)
+      "Cat1:\n  abc       description\nCat2:\n  defghi    something"
+
+      iex> format_categories_list([{"Cat1", []}], "empty category")
+      "Cat1:\n  empty category"
+
+      iex> format_categories_list([])
+      ""
+  """
+  @spec format_categories_list(categories(), String.t()) :: String.t()
+  def format_categories_list(list, empty_category \\ "nothing here") do
+    column_width =
+      list
+      |> Enum.flat_map(fn {_category, rows} -> rows end)
+      |> Enum.map(fn {name, _description} -> String.length(name) end)
+      |> Enum.max(&>=/2, fn -> 0 end)
+
+    list
+    |> Enum.map(fn
+      {category, []} -> "#{category}:\n  #{empty_category}"
+      {category, rows} -> "#{category}:\n#{format_rows(rows, column_width)}"
+    end)
+    |> Enum.join("\n")
+  end
+
+  defp format_rows(rows, width) do
+    rows
+    |> Enum.map(fn {name, description} ->
+      "  " <> String.pad_trailing(name, width) <> "    " <> description
+    end)
+    |> Enum.join("\n")
+  end
+end

--- a/lib/mobius/cogs/help.ex
+++ b/lib/mobius/cogs/help.ex
@@ -5,10 +5,20 @@ defmodule Mobius.Cogs.Help do
 
   import Mobius.Actions.Message
 
+  alias Mobius.Core.Command
   # Unsafe to use for 3rd party cogs
   alias Mobius.Services.CogLoader
 
-  @doc "Wow"
+  @header """
+  Type `[p]help Cog` for help about a specific cog
+  Type `[p]help command` for help about a specific command
+  """
+
+  @footer """
+  Made with Mobius, a general purpose bot written in Elixir
+  """
+
+  @doc "This command"
   command "help", context do
     cogs = CogLoader.list_cogs()
 
@@ -17,19 +27,24 @@ defmodule Mobius.Cogs.Help do
       |> Enum.map(&format_cog/1)
       |> Enum.join("\n")
 
-    send_message(%{content: "```#{cogs_list}```"}, context.channel_id)
+    send_message(%{content: "#{@header}```#{cogs_list}```#{@footer}"}, context.channel_id)
   end
 
   defp format_cog(%Mobius.Cog{name: name, commands: commands}) do
     commands_list =
       commands
+      |> Enum.filter(fn %Command{description: description} -> description != false end)
       |> Enum.map(&format_command/1)
       |> Enum.join("\n")
 
-    "#{name}:\n#{commands_list}"
+    if commands_list == "" do
+      "#{name}:\n    has no commands"
+    else
+      "#{name}:\n#{commands_list}"
+    end
   end
 
-  defp format_command(%Mobius.Core.Command{name: name, description: description}) do
+  defp format_command(%Command{name: name, description: description}) do
     "    #{name}        #{description}"
   end
 end

--- a/lib/mobius/cogs/help.ex
+++ b/lib/mobius/cogs/help.ex
@@ -19,15 +19,19 @@ defmodule Mobius.Cogs.Help do
   """
 
   @doc "This command"
-  command "help", context do
+  command "help", context, part: :string do
     cogs = CogLoader.list_cogs()
 
+    send_message(%{content: format_cogs(cogs)}, context.channel_id)
+  end
+
+  defp format_cogs(cogs) do
     cogs_list =
       cogs
       |> Enum.map(&format_cog/1)
       |> Enum.join("\n")
 
-    send_message(%{content: "#{@header}```#{cogs_list}```#{@footer}"}, context.channel_id)
+    "#{@header}```#{cogs_list}```#{@footer}"
   end
 
   defp format_cog(%Mobius.Cog{name: name, commands: commands}) do

--- a/lib/mobius/cogs/help.ex
+++ b/lib/mobius/cogs/help.ex
@@ -19,27 +19,94 @@ defmodule Mobius.Cogs.Help do
   Made with Mobius, a general purpose bot written in Elixir
   """
 
+  @cog_footer """
+  Type `[p]help command` for help about a specific command
+  """
+
+  @not_found """
+  Cog or command not found. Use `[p]help` for a list of cogs and commands.
+  """
+
   @doc "This command"
   command "help", context do
+    CogLoader.list_cogs()
+    |> format_cogs()
+    |> reply(context.channel_id)
+  end
+
+  @doc """
+  Shows help for a cog or a command
+
+  The name is case sensitive to distinguish between cog names and command names.
+  For example `[p]help Help` shows the cog, but `[p]help help` shows the command.
+  """
+  command "help", context, cog_or_command_name: :string do
     cogs = CogLoader.list_cogs()
 
-    send_message(%{content: format_cogs(cogs)}, context.channel_id)
+    cog_or_command_name
+    |> try_cog(cogs)
+    |> try_command(cog_or_command_name, cogs)
+    |> reply(context.channel_id)
+  end
+
+  defp try_cog(part, cogs) do
+    case find_cog(part, cogs) do
+      %Cog{} = cog -> format_specific_cog(cog)
+      _ -> nil
+    end
+  end
+
+  defp try_command(content, _part, _cogs) when is_binary(content), do: content
+
+  defp try_command(nil, part, cogs) do
+    case find_command(part, cogs) do
+      arities when is_map(arities) -> format_specific_command(arities)
+      _ -> nil
+    end
+  end
+
+  defp format_specific_cog(%Cog{} = cog) do
+    commands =
+      cog
+      |> list_command_names()
+      |> Enum.map(fn name -> "    " <> name end)
+      |> Enum.join("\n")
+
+    "#{cog.description}\n```Commands:\n#{commands}```#{@cog_footer}"
+  end
+
+  defp format_specific_command(arities) do
+    arities
+    |> Enum.flat_map(fn {_arity, clauses} -> clauses end)
+    |> Enum.sort_by(&Command.arg_count/1)
+    |> Enum.map(&format_specific_clause/1)
+    |> Enum.join("\n\n")
+  end
+
+  defp format_specific_clause(%Command{} = clause) do
+    args =
+      clause.args
+      |> Enum.map(fn {name, type} -> " {#{name} (#{type})}" end)
+      |> Enum.join()
+
+    "`[p]#{clause.name}#{args}`\n#{clause.description}"
   end
 
   defp format_cogs(cogs) do
     cogs_list =
       cogs
+      |> Enum.filter(fn %Cog{description: description} -> description != false end)
       |> Enum.map(&format_cog/1)
       |> Enum.join("\n")
 
     "#{@header}```#{cogs_list}```#{@footer}"
   end
 
-  defp format_cog(%Cog{name: name, commands: commands}) do
+  defp format_cog(%Cog{name: name} = cog) do
     commands_list =
-      commands
-      |> Enum.filter(fn %Command{description: description} -> description != false end)
-      |> Enum.map(&format_command/1)
+      cog
+      |> list_command_names()
+      |> Enum.map(fn name -> "    " <> name end)
       |> Enum.join("\n")
 
     if commands_list == "" do
@@ -49,7 +116,24 @@ defmodule Mobius.Cogs.Help do
     end
   end
 
-  defp format_command(%Command{name: name, description: description}) do
-    "    #{name}        #{description}"
+  defp list_command_names(%Cog{commands: commands}) do
+    commands
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp find_cog(cog_name, cogs) do
+    Enum.find(cogs, fn %Cog{name: name} -> name == cog_name end)
+  end
+
+  defp find_command(command_name, cogs) do
+    Enum.find_value(cogs, fn %Cog{commands: commands} -> Map.get(commands, command_name) end)
+  end
+
+  defp reply(nil, channel_id), do: reply(@not_found, channel_id)
+
+  defp reply(content, channel_id) do
+    send_message(%{content: content, allowed_mentions: %{parse: []}}, channel_id)
   end
 end

--- a/lib/mobius/cogs/help.ex
+++ b/lib/mobius/cogs/help.ex
@@ -1,0 +1,35 @@
+defmodule Mobius.Cogs.Help do
+  @moduledoc "The help command's cog"
+
+  use Mobius.Cog
+
+  import Mobius.Actions.Message
+
+  # Unsafe to use for 3rd party cogs
+  alias Mobius.Services.CogLoader
+
+  @doc "Wow"
+  command "help", context do
+    cogs = CogLoader.list_cogs()
+
+    cogs_list =
+      cogs
+      |> Enum.map(&format_cog/1)
+      |> Enum.join("\n")
+
+    send_message(%{content: "```#{cogs_list}```"}, context.channel_id)
+  end
+
+  defp format_cog(%Mobius.Cog{name: name, commands: commands}) do
+    commands_list =
+      commands
+      |> Enum.map(&format_command/1)
+      |> Enum.join("\n")
+
+    "#{name}:\n#{commands_list}"
+  end
+
+  defp format_command(%Mobius.Core.Command{name: name, description: description}) do
+    "    #{name}        #{description}"
+  end
+end

--- a/lib/mobius/cogs/help.ex
+++ b/lib/mobius/cogs/help.ex
@@ -3,15 +3,13 @@ defmodule Mobius.Cogs.Help do
 
   use Mobius.Cog
 
-  import Mobius.Actions.Message
-
   alias Mobius.CogUtils
   # Unsafe to use for 3rd party cogs
   alias Mobius.Core.Cog
   alias Mobius.Core.Command
   alias Mobius.Services.CogLoader
 
-  @header """
+  @help_footer """
   Type `[p]help Cog` for help about a specific cog
   Type `[p]help command` for help about a specific command
   """
@@ -25,10 +23,10 @@ defmodule Mobius.Cogs.Help do
   """
 
   @doc "This command"
-  command "help", context do
+  command "help" do
     CogLoader.list_cogs()
     |> format_cogs()
-    |> reply(context.channel_id)
+    |> reply()
   end
 
   @doc """
@@ -37,13 +35,13 @@ defmodule Mobius.Cogs.Help do
   The name is case sensitive to distinguish between cog names and command names.
   For example `[p]help Help` shows the cog, but `[p]help help` shows the command.
   """
-  command "help", context, cog_or_command_name: :string do
+  command "help", cog_or_command_name: :string do
     cogs = CogLoader.list_cogs()
 
     cog_or_command_name
     |> try_cog(cogs)
     |> try_command(cog_or_command_name, cogs)
-    |> reply(context.channel_id)
+    |> reply()
   end
 
   defp try_cog(part, cogs) do
@@ -93,7 +91,7 @@ defmodule Mobius.Cogs.Help do
       |> Enum.map(fn %Cog{name: name} = cog -> {name, list_cog_commands(cog)} end)
       |> CogUtils.format_categories_list("has no commands")
 
-    "#{@header}```#{cogs_list}```"
+    "```#{cogs_list}```#{@help_footer}"
   end
 
   defp list_cog_commands(%Cog{commands: commands}) do
@@ -117,9 +115,9 @@ defmodule Mobius.Cogs.Help do
     Enum.find_value(cogs, fn %Cog{commands: commands} -> Map.get(commands, command_name) end)
   end
 
-  defp reply(nil, channel_id), do: reply(@not_found, channel_id)
+  defp reply(nil), do: {:reply, %{content: @not_found}}
 
-  defp reply(content, channel_id) do
-    send_message(%{content: content, allowed_mentions: %{parse: []}}, channel_id)
+  defp reply(content) do
+    {:reply, %{content: content, allowed_mentions: %{parse: []}}}
   end
 end

--- a/lib/mobius/cogs/help.ex
+++ b/lib/mobius/cogs/help.ex
@@ -100,13 +100,7 @@ defmodule Mobius.Cogs.Help do
   defp list_cog_commands(%Cog{commands: commands}) do
     commands
     |> Enum.sort_by(fn {name, _clauses} -> name end)
-    |> Enum.map(fn {name, arities} -> {name, find_command_description(arities)} end)
-  end
-
-  defp find_command_description(arities) do
-    {_arity, commands} = Enum.min_by(arities, fn {arity, _commands} -> arity end)
-
-    Enum.find_value(commands, "", fn %Command{description: description} -> description end)
+    |> Enum.map(fn {name, arities} -> {name, Command.find_command_description(arities)} end)
   end
 
   defp find_cog(cog_name, cogs) do

--- a/lib/mobius/cogs/help.ex
+++ b/lib/mobius/cogs/help.ex
@@ -66,11 +66,7 @@ defmodule Mobius.Cogs.Help do
   end
 
   defp format_specific_cog(%Cog{} = cog) do
-    commands =
-      cog
-      |> list_command_names()
-      |> Enum.map(fn name -> "    " <> name end)
-      |> Enum.join("\n")
+    commands = list_cog_commands(cog)
 
     "#{cog.description}\n```Commands:\n#{commands}```#{@cog_footer}"
   end
@@ -89,7 +85,7 @@ defmodule Mobius.Cogs.Help do
       |> Enum.map(fn {name, type} -> " {#{name} (#{type})}" end)
       |> Enum.join()
 
-    "`[p]#{clause.name}#{args}`\n#{clause.description}"
+    "**`[p]#{clause.name}#{args}`**\n#{clause.description}"
   end
 
   defp format_cogs(cogs) do
@@ -103,11 +99,7 @@ defmodule Mobius.Cogs.Help do
   end
 
   defp format_cog(%Cog{name: name} = cog) do
-    commands_list =
-      cog
-      |> list_command_names()
-      |> Enum.map(fn name -> "    " <> name end)
-      |> Enum.join("\n")
+    commands_list = list_cog_commands(cog)
 
     if commands_list == "" do
       "#{name}:\n    has no commands"
@@ -116,11 +108,18 @@ defmodule Mobius.Cogs.Help do
     end
   end
 
-  defp list_command_names(%Cog{commands: commands}) do
+  defp list_cog_commands(%Cog{commands: commands}) do
     commands
-    |> Enum.map(&elem(&1, 0))
-    |> Enum.uniq()
-    |> Enum.sort()
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map(fn {name, arities} -> "    #{name}    #{find_command_description(arities)}" end)
+    |> Enum.join("\n")
+  end
+
+  defp find_command_description(arities) do
+    arities
+    |> Enum.min_by(&elem(&1, 0))
+    |> elem(1)
+    |> Enum.find_value("", fn %Command{description: description} -> description end)
   end
 
   defp find_cog(cog_name, cogs) do

--- a/lib/mobius/cogs/ping_pong.ex
+++ b/lib/mobius/cogs/ping_pong.ex
@@ -6,6 +6,6 @@ defmodule Mobius.Cogs.PingPong do
   import Mobius.Actions.Message
 
   command "ping", context do
-    send_message(%{content: "Pong!"}, context["channel_id"])
+    send_message(%{content: "Pong!"}, context.channel_id)
   end
 end

--- a/lib/mobius/core/cog.ex
+++ b/lib/mobius/core/cog.ex
@@ -1,6 +1,8 @@
 defmodule Mobius.Core.Cog do
   @moduledoc false
 
+  alias Mobius.Core.Command
+
   @enforce_keys [:name, :module, :description, :commands]
   defstruct [:name, :module, :description, :commands]
 

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -5,7 +5,7 @@ defmodule Mobius.Core.Command do
   alias Mobius.Models.Message
 
   @enforce_keys [:name, :args, :handler]
-  defstruct [:name, :args, :handler]
+  defstruct name: nil, args: nil, handler: nil, description: ""
 
   @type t :: %__MODULE__{
           name: String.t(),

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -61,7 +61,7 @@ defmodule Mobius.Core.Command do
   Returns a description for a command based on its `t:command_arities/0`
 
   It returns the description of the first clause which has a description out of the clauses
-  with the lowest arity
+  with the lowest arity.
   """
   @spec find_command_description(command_arities()) :: String.t()
   def find_command_description(arities) do

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -57,6 +57,19 @@ defmodule Mobius.Core.Command do
     |> Map.new(fn {name, commands} -> {name, Enum.group_by(commands, &arg_count/1)} end)
   end
 
+  @doc """
+  Returns a description for a command based on its `t:command_arities/0`
+
+  It returns the description of the first clause which has a description out of the clauses
+  with the lowest arity
+  """
+  @spec find_command_description(command_arities()) :: String.t()
+  def find_command_description(arities) do
+    {_arity, commands} = Enum.min_by(arities, fn {arity, _commands} -> arity end)
+
+    Enum.find_value(commands, "", fn %__MODULE__{description: description} -> description end)
+  end
+
   defp get_command(commands, name) do
     case Map.fetch(commands, name) do
       :error -> :not_a_command

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -14,11 +14,8 @@ defmodule Mobius.Core.Command do
           handler: function()
         }
 
-  @type processed :: %{
-          String.t() => %{
-            non_neg_integer() => [t()]
-          }
-        }
+  @type command_arities :: %{non_neg_integer() => [t()]}
+  @type processed :: %{String.t() => command_arities()}
 
   @type handle_message_result ::
           {:ok, any()}

--- a/lib/mobius/rest/client.ex
+++ b/lib/mobius/rest/client.ex
@@ -38,6 +38,7 @@ defmodule Mobius.Rest.Client do
     :fuse.reset(__MODULE__)
 
     middleware = [
+      Tesla.Middleware.KeepRequest,
       {Tesla.Middleware.Fuse, fuse_opts},
       {Tesla.Middleware.Retry, max_retries: retries, should_retry: &client_should_retry?/1},
       Mobius.Rest.Middleware.Ratelimit,

--- a/lib/mobius/validations/action_validations.ex
+++ b/lib/mobius/validations/action_validations.ex
@@ -17,9 +17,7 @@ defmodule Mobius.Validations.ActionValidations do
           :ok
         else
           {:error,
-           "Expected #{key} to contain between #{min} and #{max} characters, got #{value} with #{
-             string_length
-           } characters"}
+           "Expected #{key} to contain between #{min} and #{max} characters, got #{value} with #{string_length} characters"}
         end
 
       _ ->

--- a/test/mobius/actions/channel_test.exs
+++ b/test/mobius/actions/channel_test.exs
@@ -101,8 +101,6 @@ defmodule Mobius.Actions.ChannelTest do
   defp assert_has_error(errors, expected_error)
        when is_list(errors) and is_binary(expected_error) do
     assert Enum.any?(errors, fn error -> error =~ expected_error end),
-           "Error message not found. Expected #{inspect(expected_error)}, received #{
-             inspect(errors)
-           }."
+           "Error message not found. Expected #{inspect(expected_error)}, received #{inspect(errors)}."
   end
 end

--- a/test/mobius/cog_utils_test.exs
+++ b/test/mobius/cog_utils_test.exs
@@ -1,0 +1,5 @@
+defmodule Mobius.CogUtilsTest do
+  use ExUnit.Case, async: true
+
+  doctest Mobius.CogUtils, import: true
+end

--- a/test/mobius/cogs/help_test.exs
+++ b/test/mobius/cogs/help_test.exs
@@ -1,0 +1,74 @@
+defmodule Mobius.Cogs.HelpTest do
+  use Mobius.CogCase, something: :test
+
+  alias Mobius.Core.Cog
+  alias Mobius.Services.CogLoader
+
+  describe "[p]help" do
+    test "has a footer describing the other commands" do
+      send_command_payload("help")
+
+      assert_message_sent(%{content: content})
+
+      assert String.ends_with?(
+               content,
+               "Type `[p]help Cog` for help about a specific cog\n" <>
+                 "Type `[p]help command` for help about a specific command\n"
+             )
+    end
+
+    test "lists the cogs" do
+      send_command_payload("help")
+
+      assert_message_sent(%{content: content})
+
+      CogLoader.list_cogs()
+      |> Enum.all?(fn %Cog{name: name} -> content =~ name end)
+      |> assert
+    end
+
+    test "lists itself and its command" do
+      send_command_payload("help")
+
+      assert_message_sent(%{content: content})
+      assert content =~ "Help:\n  help    This command"
+    end
+  end
+
+  describe "[p]help Cog/command" do
+    test "replies with not found if no cog or command is found" do
+      send_command_payload("help ----")
+
+      assert_message_sent(%{content: content})
+      assert content =~ "Cog or command not found"
+    end
+
+    test "replies with cog description if cog is found" do
+      send_command_payload("help Help")
+
+      assert_message_sent(%{content: content})
+      assert content =~ "The help command's cog"
+    end
+
+    test "replies with cog commands if cog is found" do
+      send_command_payload("help Help")
+
+      assert_message_sent(%{content: content})
+      assert content =~ "Commands:\n  help    This command"
+    end
+
+    test "replies with footer if cog is found" do
+      send_command_payload("help Help")
+
+      assert_message_sent(%{content: content})
+      assert content =~ "Type `[p]help command` for help about a specific command"
+    end
+
+    test "replies with each clause if command is found" do
+      send_command_payload("help help")
+
+      assert_message_sent(%{content: content})
+      assert content =~ "`[p]help`" and content =~ "`[p]help {cog_or_command_name (string)}`"
+    end
+  end
+end

--- a/test/support/cog_case.ex
+++ b/test/support/cog_case.ex
@@ -1,0 +1,27 @@
+defmodule Mobius.CogCase do
+  @moduledoc """
+  This module defines the test case to be used by tests that require setting up a cog.
+
+  Such tests will have access to all functions in `Mobius.CogTestUtils`
+
+  It will also setup the necessary mocks and prepare the bot's state to receive events
+  """
+
+  use ExUnit.CaseTemplate
+
+  import Mobius.Fixtures
+  import Mobius.CogTestUtils
+
+  using _opts do
+    quote do
+      import Mobius.Fixtures, only: [send_command_payload: 1]
+      import Mobius.CogTestUtils
+    end
+  end
+
+  setup :get_shard
+  setup :reset_services
+  setup :stub_socket
+  setup :handshake_shard
+  setup :setup_rest_api_mock
+end

--- a/test/support/cog_test_utils.ex
+++ b/test/support/cog_test_utils.ex
@@ -39,7 +39,18 @@ defmodule Mobius.CogTestUtils do
     end)
   end
 
-  @doc "Asserts that a message was sent returns the body of the request"
+  @doc """
+  Asserts and matches on the body of a message send request
+
+  ## Usage
+
+    iex> assert_message_sent(%{content: "My message"})
+
+    iex> assert_message_sent(%{content: content})
+    iex> assert content =~ "the middle of the message"
+
+    iex> assert_message_sent(%{tts: true})
+  """
   @spec assert_message_sent(Message.message_body()) :: any
   defmacro assert_message_sent(expectation) do
     quote do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,4 +3,4 @@ Mobius.Fixtures.mock_gateway_bot()
 
 Application.ensure_all_started(:mobius)
 
-ExUnit.start(capture_log: true)
+ExUnit.start(capture_log: true, exclude: [:skip])


### PR DESCRIPTION
Added the `Help` cog which supports:
- [x] `[p]help`
- [x] `[p]help <cog>`
- [x] `[p]help <command>`

The cog is autoloaded by default.

Closes #76 