### PR TITLE
feat: Supporting overloaded commands

### DIFF
--- a/lib/mobius/cog.ex
+++ b/lib/mobius/cog.ex
@@ -244,17 +244,12 @@ defmodule Mobius.Cog do
       handler: Function.capture(__CALLER__.module, handler_name, length(args) + 1)
     }
 
-    arg_vars =
-      args
-      |> Enum.map(fn {variable, type} -> {type, Macro.var(variable, nil)} end)
-      |> Macro.escape()
-
-    contents = Macro.escape(block, unquote: true)
+    arg_vars = Enum.map(args, fn {variable, type} -> {type, Macro.var(variable, nil)} end)
 
     quote bind_quoted: [
             handler_name: handler_name,
-            contents: contents,
-            arg_vars: arg_vars,
+            contents: Macro.escape(block, unquote: true),
+            arg_vars: Macro.escape(arg_vars),
             context: Macro.escape(context),
             command: Macro.escape(new_command),
             line: __CALLER__.line,

--- a/lib/mobius/cog.ex
+++ b/lib/mobius/cog.ex
@@ -245,10 +245,8 @@ defmodule Mobius.Cog do
     }
 
     arg_vars =
-      new_command
-      |> Command.arg_names()
-      |> Enum.map(&String.to_existing_atom/1)
-      |> Enum.map(&Macro.var(&1, nil))
+      args
+      |> Enum.map(fn {variable, type} -> {type, Macro.var(variable, nil)} end)
       |> Macro.escape()
 
     contents = Macro.escape(block, unquote: true)
@@ -264,21 +262,10 @@ defmodule Mobius.Cog do
           ] do
       existing_commands = Module.get_attribute(__MODULE__, :commands)
 
-      if Module.defines?(__MODULE__, {handler_name, 0}) do
-        reraise(
-          %CompileError{
-            line: line,
-            file: file,
-            description: "Command \"#{command.name}\" already exists."
-          },
-          []
-        )
-      else
-        Module.put_attribute(__MODULE__, :commands, command)
+      Module.put_attribute(__MODULE__, :commands, command)
 
-        def unquote(handler_name)(unquote(context), unquote_splicing(arg_vars)),
-          do: unquote(contents)
-      end
+      def unquote(handler_name)(unquote(context), unquote_splicing(arg_vars)),
+        do: unquote(contents)
     end
   end
 

--- a/lib/mobius/cog.ex
+++ b/lib/mobius/cog.ex
@@ -81,8 +81,10 @@ defmodule Mobius.Cog do
       alias Mobius.Actions.Events
       alias Mobius.Services.Bot
 
+      @computed_commands Enum.reverse(@commands)
+
       listen :message_create, message do
-        case Command.execute_command(@commands, Bot.get_global_prefix!(), message) do
+        case Command.execute_command(@computed_commands, Bot.get_global_prefix!(), message) do
           {:ok, _} ->
             :ok
 

--- a/lib/mobius/cog.ex
+++ b/lib/mobius/cog.ex
@@ -88,7 +88,7 @@ defmodule Mobius.Cog do
 
           {:too_few_args, command, received} ->
             Logger.info(
-              "Too few arguments for command \"#{command.name}\". Expected #{
+              "Wrong number of arguments for command \"#{command.name}\". Expected #{
                 Command.arg_count(command)
               } arguments, got #{received}."
             )

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -77,7 +77,7 @@ defmodule Mobius.Core.Command do
     if errors != [] do
       {:invalid_args, Enum.map(errors, fn {arg, value, _} -> {arg, value} end)}
     else
-      {:ok, Enum.map(valids, fn {_, _, val} -> val end)}
+      {:ok, Enum.map(valids, fn {{_name, type}, _, val} -> {type, val} end)}
     end
   end
 

--- a/test/mobius/cog_test.exs
+++ b/test/mobius/cog_test.exs
@@ -55,23 +55,22 @@ defmodule Mobius.CogTest do
       assert_receive "hello"
     end
 
-    test "should parse integer arguments" do
-      send_command_payload("add 1 2")
-
-      assert_receive 3
+    test "should call the clause with matching types" do
+      send_command_payload("reply 5")
+      assert_receive 15
     end
 
-    test "should notify of wrong number of arguments" do
+    test "should notify of wrong number of arguments if no clause matches" do
       assert capture_log(fn ->
-               send_command_payload("add 1")
+               send_command_payload("reply")
                Process.sleep(10)
              end) =~
-               "Wrong number of arguments for command \"add\". Expected 2 arguments, got 1."
+               "Wrong number of arguments for command \"reply\". Expected 1 arguments, got 0."
     end
 
     test "should notify of invalid arguments" do
       assert capture_log(fn ->
-               send_command_payload("add 2 hello")
+               send_command_payload("reply 2 hello")
                Process.sleep(10)
              end) =~
                ~s'Invalid type for argument "num2". Expected "integer", got "hello".'
@@ -79,10 +78,10 @@ defmodule Mobius.CogTest do
   end
 
   describe "command/4" do
-    test "should be called with the context and the parsed arguments" do
+    test "executes the first matching clause from top to bottom" do
       message = send_command_payload("everything 123")
 
-      assert_receive {:everything, ^message, 123}
+      assert_receive {:everything, ^message, "123"}
     end
   end
 end

--- a/test/mobius/cog_test.exs
+++ b/test/mobius/cog_test.exs
@@ -61,12 +61,12 @@ defmodule Mobius.CogTest do
       assert_receive 3
     end
 
-    test "should notify of missing arguments" do
+    test "should notify of wrong number of arguments" do
       assert capture_log(fn ->
                send_command_payload("add 1")
                Process.sleep(10)
              end) =~
-               "Too few arguments for command \"add\". Expected 2 arguments, got 1."
+               "Wrong number of arguments for command \"add\". Expected 2 arguments, got 1."
     end
 
     test "should notify of invalid arguments" do

--- a/test/mobius/cog_test.exs
+++ b/test/mobius/cog_test.exs
@@ -50,27 +50,27 @@ defmodule Mobius.CogTest do
     end
 
     test "should be called when messages starting with command name are received" do
-      send_command_payload("reply hello")
+      send_command_payload("add hello")
 
-      assert_receive "hello"
+      assert_receive {:unsupported, "hello"}
     end
 
     test "should call the clause with matching types" do
-      send_command_payload("reply 5")
-      assert_receive 15
+      send_command_payload("add 5")
+      assert_receive 5
     end
 
     test "should notify of wrong number of arguments if no clause matches" do
       assert capture_log(fn ->
-               send_command_payload("reply")
+               send_command_payload("add")
                Process.sleep(10)
              end) =~
-               "Wrong number of arguments for command \"reply\". Expected 1 arguments, got 0."
+               "Wrong number of arguments for command \"add\". Expected 1 arguments, got 0."
     end
 
     test "should notify of invalid arguments" do
       assert capture_log(fn ->
-               send_command_payload("reply 2 hello")
+               send_command_payload("add 2 hello")
                Process.sleep(10)
              end) =~
                ~s'Invalid type for argument "num2". Expected "integer", got "hello".'

--- a/test/support/cog_stub.ex
+++ b/test/support/cog_stub.ex
@@ -17,16 +17,24 @@ defmodule Mobius.Stubs.Cog do
     send_to_test(context)
   end
 
+  command "reply", value: :integer do
+    send_to_test(value + 10)
+  end
+
   command "reply", message: :string do
     send_to_test(message)
   end
 
-  command "add", num1: :integer, num2: :integer do
+  command "reply", num1: :integer, num2: :integer do
     send_to_test(num1 + num2)
   end
 
-  command "everything", context, value: :integer do
+  command "everything", context, value: :string do
     send_to_test({:everything, context, value})
+  end
+
+  command "everything", value: :integer do
+    send_to_test({:unexpected_everything, value})
   end
 
   defp send_to_test(message) do

--- a/test/support/cog_stub.ex
+++ b/test/support/cog_stub.ex
@@ -17,15 +17,15 @@ defmodule Mobius.Stubs.Cog do
     send_to_test(context)
   end
 
-  command "reply", value: :integer do
-    send_to_test(value + 10)
+  command "add", value: :integer do
+    send_to_test(value)
   end
 
-  command "reply", message: :string do
-    send_to_test(message)
+  command "add", message: :string do
+    send_to_test({:unsupported, message})
   end
 
-  command "reply", num1: :integer, num2: :integer do
+  command "add", num1: :integer, num2: :integer do
     send_to_test(num1 + num2)
   end
 


### PR DESCRIPTION
This PR is the first step towards supporting everything needed for #76 (cog docs, command docs, and command overloading)

This PR adds support for command overloading in a naive way. A future PR will refactor this implementation to make it both more efficient and more readable. Since that refactoring will touch multiple modules, I preferred splitting the PR into one which adds the feature and another which refactors it.

Note: command overloading means the same command with a different arity and/or different types on the arguments. This implementation supports both different arities and different types.