### PR TITLE
refactor: Command execution

### DIFF
--- a/config/config_test.exs
+++ b/config/config_test.exs
@@ -5,6 +5,7 @@ config :ex_unit,
   refute_receive_timeout: 75
 
 config :mobius,
+  default_global_prefix: "sudo ",
   resuming_sleep_time_ms: 75,
   ratelimiter_impl: Mobius.Stubs.CommandsRatelimiter,
   connection_ratelimiter_impl: Mobius.Stubs.ConnectionRatelimiter,

--- a/lib/mobius/cog.ex
+++ b/lib/mobius/cog.ex
@@ -83,17 +83,15 @@ defmodule Mobius.Cog do
 
       @computed_commands Command.preprocess_commands(@commands)
 
-      defp __commands__, do: @computed_commands
-
       listen :message_create, message do
-        case Command.execute_command(__commands__(), Bot.get_global_prefix!(), message) do
+        case Command.execute_command(@computed_commands, Bot.get_global_prefix!(), message) do
           {:ok, _} ->
             :ok
 
           {:too_few_args, arities, received} ->
             Logger.info(
               "Wrong number of arguments. Expected one of #{
-                Enum.join(Enum.map(arities, &Integer.to_string/1), ", ")
+                arities |> Enum.map(&Integer.to_string/1) |> Enum.join(", ")
               } arguments, got #{received}."
             )
 

--- a/lib/mobius/cogs/ping_pong.ex
+++ b/lib/mobius/cogs/ping_pong.ex
@@ -6,6 +6,6 @@ defmodule Mobius.Cogs.PingPong do
   import Mobius.Actions.Message
 
   command "ping", context do
-    send_message(%{content: "Pong!"}, context["channel_id"])
+    send_message(%{content: "Pong!"}, context.channel_id)
   end
 end

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -13,11 +13,17 @@ defmodule Mobius.Core.Command do
           handler: function()
         }
 
+  @type processed :: %{
+          String.t() => %{
+            non_neg_integer() => [t()]
+          }
+        }
+
   @type handle_message_result ::
           {:ok, any()}
           | :not_a_command
-          | {:too_few_args, t(), non_neg_integer()}
-          | {:invalid_args, [{{atom(), ArgumentParser.arg_type()}, String.t()}]}
+          | {:too_few_args, [non_neg_integer()], non_neg_integer()}
+          | {:invalid_args, [t]}
 
   @spec command_handler_name(String.t()) :: atom()
   def command_handler_name(command_name) do
@@ -34,47 +40,42 @@ defmodule Mobius.Core.Command do
   @spec arg_count(t()) :: non_neg_integer()
   def arg_count(%__MODULE__{} = command), do: length(command.args)
 
-  @spec execute_command([t()], String.t(), Message.t()) :: handle_message_result()
+  @spec execute_command(processed(), String.t(), Message.t()) :: handle_message_result()
   def execute_command(commands, prefix, %Message{content: content} = message) do
-    arg_values = split_arguments(content)
-
-    Enum.reduce_while(commands, :not_a_command, fn %__MODULE__{} = command, acc ->
-      new =
-        cond do
-          not String.starts_with?(content, prefix <> command.name) -> :not_a_command
-          arg_count(command) != length(arg_values) -> {:too_few_args, command, length(arg_values)}
-          true -> try_command(command, arg_values, message)
-        end
-
-      decide_by_priority(acc, new)
-    end)
-  end
-
-  defp decide_by_priority(old, new) do
-    # Overwrite the accumulator depending on a priority list:
-    # :ok (which halts the reduce) > :invalid_args > :too_few_args > :not_a_command
-    # All the :cont are to let other clauses have their chance
-    # However if one of the clauses has the right amount of args, but wrong types, that's the
-    #   error we want to return ultimately if no other clause matches those arguments
-    # Same logic applies for :too_few_args, if one clause is the right command with the wrong
-    #   amount of args, but no other clause matches the command, that's the error we want
-    # Finally, if none of the commands matches, we return :not_a_command
-    case {old, new} do
-      {{:ok, _} = value, _} -> {:halt, value}
-      {_, {:ok, _} = value} -> {:halt, value}
-      {{:invalid_args, _} = value, _} -> {:cont, value}
-      {_, {:invalid_args, _} = value} -> {:cont, value}
-      {{:too_few_args, _, _} = value, _} -> {:cont, value}
-      {_, {:too_few_args, _, _} = value} -> {:cont, value}
-      {:not_a_command, _} -> {:cont, :not_a_command}
-      {_, :not_a_command} -> {:cont, :not_a_command}
-    end
-  end
-
-  defp try_command(command, arg_values, %Message{} = message) do
-    with {:ok, values} <- parse_arg_values(command, arg_values) do
+    with {:ok, content} <- match_prefix(prefix, content),
+         {:ok, name, arg_values} <- split_arguments(content),
+         {:ok, groups} <- get_command(commands, name),
+         {:ok, clauses} <- get_clauses(groups, length(arg_values)),
+         {:ok, command, values} <- find_clause(clauses, arg_values) do
       {:ok, apply(command.handler, [message | values])}
     end
+  end
+
+  @spec preprocess_commands([t()]) :: processed()
+  def preprocess_commands(commands) do
+    commands
+    |> Enum.reverse()
+    |> Enum.group_by(fn %__MODULE__{name: name} -> name end)
+    |> Enum.map(fn {name, commands} -> {name, Enum.group_by(commands, &arg_count/1)} end)
+    |> Map.new()
+  end
+
+  defp get_command(commands, name) do
+    case Map.fetch(commands, name) do
+      :error -> :not_a_command
+      {:ok, clause_groups} -> {:ok, clause_groups}
+    end
+  end
+
+  defp get_clauses(clause_groups, arity) do
+    case Map.fetch(clause_groups, arity) do
+      :error -> {:too_few_args, Map.keys(clause_groups), arity}
+      {:ok, clauses} -> {:ok, clauses}
+    end
+  end
+
+  defp find_clause(clauses, arg_values) do
+    Enum.find_value(clauses, {:invalid_args, clauses}, &parse_arg_values(&1, arg_values))
   end
 
   defp parse_arg_values(%__MODULE__{} = command, values) do
@@ -86,16 +87,23 @@ defmodule Mobius.Core.Command do
       end)
       |> Enum.split_with(fn {_, _, parse_result} -> parse_result == :error end)
 
-    if errors != [] do
-      {:invalid_args, Enum.map(errors, fn {arg, value, _} -> {arg, value} end)}
-    else
-      {:ok, Enum.map(valids, fn {{_name, type}, _, val} -> {type, val} end)}
+    if errors == [] do
+      {:ok, command, Enum.map(valids, fn {{_name, type}, _, val} -> {type, val} end)}
     end
   end
 
-  defp split_arguments(message) do
-    message
-    |> String.split()
-    |> tl()
+  defp match_prefix(prefix, content) do
+    if String.starts_with?(content, prefix) do
+      {:ok, String.replace_prefix(content, prefix, "")}
+    else
+      :not_a_command
+    end
+  end
+
+  defp split_arguments(content) do
+    case String.split(content) do
+      [] -> :not_a_command
+      [name | args] -> {:ok, name, args}
+    end
   end
 end

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -56,8 +56,7 @@ defmodule Mobius.Core.Command do
     commands
     |> Enum.reverse()
     |> Enum.group_by(fn %__MODULE__{name: name} -> name end)
-    |> Enum.map(fn {name, commands} -> {name, Enum.group_by(commands, &arg_count/1)} end)
-    |> Map.new()
+    |> Map.new(fn {name, commands} -> {name, Enum.group_by(commands, &arg_count/1)} end)
   end
 
   defp get_command(commands, name) do

--- a/lib/mobius/services/bot.ex
+++ b/lib/mobius/services/bot.ex
@@ -12,6 +12,8 @@ defmodule Mobius.Services.Bot do
 
   require Logger
 
+  @default_prefix Application.compile_env(:mobius, :default_global_prefix, "!")
+
   @shards_table :mobius_shards
 
   @typep state :: %{
@@ -99,7 +101,7 @@ defmodule Mobius.Services.Bot do
     :persistent_term.put(__MODULE__, %{
       client: client,
       intents: intents,
-      global_prefix: "!"
+      global_prefix: @default_prefix
     })
 
     client

--- a/test/mobius/cog_test.exs
+++ b/test/mobius/cog_test.exs
@@ -65,7 +65,7 @@ defmodule Mobius.CogTest do
                send_command_payload("add")
                Process.sleep(10)
              end) =~
-               "Wrong number of arguments for command \"add\". Expected 1 arguments, got 0."
+               "Wrong number of arguments. Expected one of 1, 2 arguments, got 0."
     end
 
     test "should notify of invalid arguments" do
@@ -73,7 +73,7 @@ defmodule Mobius.CogTest do
                send_command_payload("add 2 hello")
                Process.sleep(10)
              end) =~
-               ~s'Invalid type for argument "num2". Expected "integer", got "hello".'
+               ~s'Type mismatch for the command "add" with 2 arguments'
     end
   end
 

--- a/test/mobius/core/command_test.exs
+++ b/test/mobius/core/command_test.exs
@@ -54,39 +54,39 @@ defmodule Mobius.Core.CommandTest do
         handler: &command_handler/4
       }
 
-      [command: command]
+      [command: command, commands: Command.preprocess_commands([command])]
     end
 
-    test "should return an error when no command matches the message" do
-      assert Command.execute_command([], "!", message("hello")) == :not_a_command
+    test "should return an error when no command matches the message", ctx do
+      assert Command.execute_command(ctx.commands, "!", message("!hi")) == :not_a_command
     end
 
-    test "should return an error when there's no prefix in the message", %{command: command} do
-      assert Command.execute_command([command], "!", message("hello")) == :not_a_command
+    test "should return an error when there's no prefix in the message", ctx do
+      assert Command.execute_command(ctx.commands, "!", message("hello")) == :not_a_command
     end
 
-    test "should return an error when there's the wrong command prefix", %{command: command} do
-      assert Command.execute_command([command], "!", message("?hello")) == :not_a_command
+    test "should return an error when there's the wrong command prefix", ctx do
+      assert Command.execute_command(ctx.commands, "!", message("?hello")) == :not_a_command
     end
 
-    test "should return an error when the command has missing arguments", %{command: command} do
-      result = Command.execute_command([command], "!", message("!hello"))
-      assert result == {:too_few_args, command, 0}
+    test "should return an error when the command has missing arguments", ctx do
+      result = Command.execute_command(ctx.commands, "!", message("!hello"))
+      assert result == {:too_few_args, [3], 0}
     end
 
-    test "should return an error when the command has invalid arguments", %{command: command} do
-      result = Command.execute_command([command], "!", message("!hello foo bar baz"))
-      assert result == {:invalid_args, [{{:foo, :integer}, "foo"}]}
+    test "should return an error when the command has invalid arguments", ctx do
+      result = Command.execute_command(ctx.commands, "!", message("!hello foo bar baz"))
+      assert result == {:invalid_args, [ctx.command]}
     end
 
-    test "should execute the command when the arguments are valid", %{command: command} do
-      Command.execute_command([command], "!", message("!hello 1 foo bar"))
+    test "should execute the command when the arguments are valid", ctx do
+      Command.execute_command(ctx.commands, "!", message("!hello 1 foo bar"))
       assert_receive({"command handled", _})
     end
 
     test "should receive the message as context when the arguments are valid", ctx do
       msg = message("!hello 1 foo bar")
-      Command.execute_command([ctx.command], "!", msg)
+      Command.execute_command(ctx.commands, "!", msg)
       assert_receive {"command handled", ^msg}
     end
   end

--- a/test/mobius/core/command_test.exs
+++ b/test/mobius/core/command_test.exs
@@ -84,6 +84,11 @@ defmodule Mobius.Core.CommandTest do
       assert_receive({"command handled", _})
     end
 
+    test "should execute the command when the prefix has a space", ctx do
+      Command.execute_command(ctx.commands, "sudo ", message("sudo hello 1 foo bar"))
+      assert_receive({"command handled", _})
+    end
+
     test "should receive the message as context when the arguments are valid", ctx do
       msg = message("!hello 1 foo bar")
       Command.execute_command(ctx.commands, "!", msg)


### PR DESCRIPTION
This PR is the followup to #79 and is the refactor talked about in there.

While doing the refactor, I found an easy way to fix #80 so that's also done :) It would have been inconvenient to not fix it at the same time. As such I changed the default prefix for tests to be "sudo " which means a lot of existing tests will be testing that prefixes with spaces work.

The pingpong cog has also been fixed. It was forgotten after #72

Note: You may notice the error messages in Cog are now partly less informative. I haven't found an easy way to do the same error messages now that multiple clauses are there. I also didn't want to spend too much effort on that so I've put in as much information as available where the errors are detected and put that in the error tuple. At the end of the day I think it's fine anyway since later on the error won't be logged, it will instead make the bot reply with the command's help message which should list all the clauses. This is an overall much better error message for end users too (especially compared to not replying at all)