### PR TITLE
feat: Using docs in cogs and commands

### DIFF
--- a/lib/mobius/cog.ex
+++ b/lib/mobius/cog.ex
@@ -53,17 +53,8 @@ defmodule Mobius.Cog do
   `handle_info/2` match a different pattern.
   """
 
+  alias Mobius.Core.Cog
   alias Mobius.Core.Command
-
-  @enforce_keys [:name, :module]
-  defstruct [:name, :module, description: "", commands: []]
-
-  @type t :: %__MODULE__{
-          module: module(),
-          name: String.t(),
-          description: String.t(),
-          commands: Command.processed()
-        }
 
   @doc false
   defmacro __using__(_call) do
@@ -95,7 +86,7 @@ defmodule Mobius.Cog do
 
       @doc false
       def __cog__ do
-        %Mobius.Cog{
+        %Cog{
           module: __MODULE__,
           name: __MODULE__ |> Module.split() |> List.last(),
           description: @moduledoc,

--- a/lib/mobius/cog.ex
+++ b/lib/mobius/cog.ex
@@ -56,7 +56,7 @@ defmodule Mobius.Cog do
   alias Mobius.Core.Command
 
   @enforce_keys [:name, :module]
-  defstruct name: nil, module: nil, description: "", commands: []
+  defstruct [:name, :module, description: "", commands: []]
 
   @type t :: %__MODULE__{
           module: module(),

--- a/lib/mobius/cogs/ping_pong.ex
+++ b/lib/mobius/cogs/ping_pong.ex
@@ -1,10 +1,11 @@
 defmodule Mobius.Cogs.PingPong do
-  @moduledoc false
+  @moduledoc "Defines the ping pong command"
 
   use Mobius.Cog
 
   import Mobius.Actions.Message
 
+  @doc ~s(Replies with "Pong!")
   command "ping", context do
     send_message(%{content: "Pong!"}, context.channel_id)
   end

--- a/lib/mobius/core/cog.ex
+++ b/lib/mobius/core/cog.ex
@@ -1,0 +1,13 @@
+defmodule Mobius.Core.Cog do
+  @moduledoc false
+
+  @enforce_keys [:name, :module, :description, :commands]
+  defstruct [:name, :module, :description, :commands]
+
+  @type t :: %__MODULE__{
+          module: module(),
+          name: String.t(),
+          description: String.t() | false | nil,
+          commands: Command.processed()
+        }
+end

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -5,10 +5,11 @@ defmodule Mobius.Core.Command do
   alias Mobius.Models.Message
 
   @enforce_keys [:name, :args, :handler]
-  defstruct [:name, :args, :handler]
+  defstruct name: nil, args: nil, handler: nil, description: ""
 
   @type t :: %__MODULE__{
           name: String.t(),
+          description: String.t() | false | nil,
           args: keyword(ArgumentParser.arg_type()),
           handler: function()
         }

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -5,7 +5,7 @@ defmodule Mobius.Core.Command do
   alias Mobius.Models.Message
 
   @enforce_keys [:name, :args, :handler]
-  defstruct name: nil, args: nil, handler: nil, description: ""
+  defstruct [:name, :args, :handler, description: ""]
 
   @type t :: %__MODULE__{
           name: String.t(),

--- a/test/mobius/cog_test.exs
+++ b/test/mobius/cog_test.exs
@@ -84,4 +84,50 @@ defmodule Mobius.CogTest do
       assert_receive {:everything, ^message, "123"}
     end
   end
+
+  describe "undocumented cog" do
+    defmodule UndocumentedCog do
+      use Mobius.Cog
+    end
+
+    test "should have nil as a description" do
+      assert nil == UndocumentedCog.__cog__().description
+    end
+  end
+
+  describe "documented cog" do
+    defmodule DocumentedCog do
+      @moduledoc "This cog is documented"
+      use Mobius.Cog
+
+      @doc "Fun command"
+      command "fun", do: nil
+
+      @doc false
+      command "hidden", do: nil
+
+      command "nodoc", do: nil
+    end
+
+    test "should keep track of the cog's doc" do
+      assert "This cog is documented" == DocumentedCog.__cog__().description
+    end
+
+    test "should keep track of command doc" do
+      assert "Fun command" == get_command(DocumentedCog, "fun").description
+    end
+
+    test "should have false as command description if @doc false is given" do
+      assert false == get_command(DocumentedCog, "hidden").description
+    end
+
+    test "should have nil as command description if no doc is given" do
+      assert nil == get_command(DocumentedCog, "nodoc").description
+    end
+  end
+
+  defp get_command(cog, command_name) do
+    cog_info = cog.__cog__()
+    hd(cog_info.commands[command_name][0])
+  end
 end

--- a/test/mobius/cog_test.exs
+++ b/test/mobius/cog_test.exs
@@ -90,7 +90,7 @@ defmodule Mobius.CogTest do
       use Mobius.Cog
     end
 
-    test "should have nil as a description" do
+    test "should not have a description" do
       assert nil == UndocumentedCog.__cog__().description
     end
   end


### PR DESCRIPTION
This PR makes `Mobius.Cog` use the `@doc` before commands and the `@moduledoc` at the top of the module for the description of the cog and the description of individual command clauses.

This feature is needed by the help command