### PR TITLE
feat: Wrap command context in a map for future proofing

### DIFF
--- a/lib/mobius/cog.ex
+++ b/lib/mobius/cog.ex
@@ -189,12 +189,20 @@ defmodule Mobius.Cog do
 
   The second parameter defines the argument where the command context will be received.
   If omitted, the command context won't be available inside the command's body.
+  The context is of type `t:Mobius.Core.Command.context/0` and contains information about the
+  command invocation such as the message which triggered the command.
 
   The third parameter defines the list of arguments that the command accepts,
   along with their type. If a user passes more arguments than are defined by the
   command, the extraneous arguments will be ignored.
   If omitted, the command will be called regardless of what comes after the name
   of the command in the message.
+
+  ## Return values
+  Commands support the following return values:
+
+  * `:ok` which does nothing
+  * `{:reply, Mobius.Actions.Message.message_body()}` sends the message in the channel where the command was invoked
 
   ## Command types
 
@@ -218,14 +226,16 @@ defmodule Mobius.Cog do
 
   command "ping", context do
     send_message(%{content: "Pong!"}, context.channel_id)
+    :ok
   end
 
   command "hello", you: :string do
-    IO.inspect(you, label: "Your name is")
+    {:reply, %{content: "Your name is #{you}"}}
   end
 
   command "add", context, num1: :integer, num2: :integer do
     send_message(%{content: "#{num1 + num2}"}, context.channel_id)
+    :ok
   end
   ```
 
@@ -236,7 +246,7 @@ defmodule Mobius.Cog do
   user: ping
   myBot: Pong!
   user: hello User
-  myBot (prints in the terminal): Your name is: "User"
+  myBot: Your name is: "User"
   user: add 1 2
   myBot: 3
   user: add 1 hello

--- a/lib/mobius/core/command.ex
+++ b/lib/mobius/core/command.ex
@@ -7,6 +7,10 @@ defmodule Mobius.Core.Command do
   @enforce_keys [:name, :args, :handler]
   defstruct [:name, :args, :handler, description: ""]
 
+  @type context :: %{
+          message: Message.t()
+        }
+
   @type t :: %__MODULE__{
           name: String.t(),
           description: String.t() | false | nil,
@@ -48,7 +52,8 @@ defmodule Mobius.Core.Command do
          {:ok, groups} <- get_command(commands, name),
          {:ok, clauses} <- get_clauses(groups, length(arg_values)),
          {:ok, command, values} <- find_clause(clauses, arg_values) do
-      {:ok, apply(command.handler, [message | values])}
+      context = %{message: message}
+      {:ok, apply(command.handler, [context | values])}
     end
   end
 

--- a/test/mobius/core/command_test.exs
+++ b/test/mobius/core/command_test.exs
@@ -98,7 +98,7 @@ defmodule Mobius.Core.CommandTest do
 
   defp message(content), do: %Message{content: content}
 
-  defp command_handler(ctx, _, _, _) do
-    send(self(), {"command handled", ctx})
+  defp command_handler(%{message: message}, _, _, _) do
+    send(self(), {"command handled", message})
   end
 end

--- a/test/support/cog_stub.ex
+++ b/test/support/cog_stub.ex
@@ -13,7 +13,7 @@ defmodule Mobius.Stubs.Cog do
     send_to_test(:nothing)
   end
 
-  command "send", context do
+  command "send", %{message: context} do
     send_to_test(context)
   end
 
@@ -29,7 +29,7 @@ defmodule Mobius.Stubs.Cog do
     send_to_test(num1 + num2)
   end
 
-  command "everything", context, value: :string do
+  command "everything", %{message: context}, value: :string do
     send_to_test({:everything, context, value})
   end
 


### PR DESCRIPTION
Instead of directly using the message which invoked the command as the context, we wrap it in a map to let us add things to the context without breaking the API in the future.

This is mainly to avoid doing a breaking change after v1 when we add features to the command context.