### PR TITLE
refactor: Use endpoint generator for list messages action

### DIFF
--- a/lib/mobius/actions.ex
+++ b/lib/mobius/actions.ex
@@ -3,7 +3,7 @@ defmodule Mobius.Actions do
   Generation of Mobius actions
 
   This module contains the macros and functions necessary to generate Mobius
-  actions form endpoint definitions.
+  actions from endpoint definitions.
 
   ## Warning about exported functions
 

--- a/lib/mobius/actions.ex
+++ b/lib/mobius/actions.ex
@@ -1,0 +1,98 @@
+defmodule Mobius.Actions do
+  @moduledoc """
+  Generation of Mobius actions
+
+  This module contains the macros and functions necessary to generate Mobius
+  actions form endpoint definitions.
+
+  ## Warning about exported functions
+
+  The functions exported by this module are not meant to be used directly. They
+  are used by the `setup_actions/1` macro, which should be considered to be the
+  sole entrypoint for this module.
+  """
+
+  alias Mobius.Endpoint
+  alias Mobius.Services.Bot
+  alias Mobius.Validations.ActionValidations
+
+  @doc """
+  Generates actions functions from a list of `Mobius.Endpoint`.
+  """
+  @spec setup_actions([Endpoint.t()]) :: Macro.output()
+  defmacro setup_actions(endpoints) do
+    quote bind_quoted: [endpoints: endpoints], location: :keep do
+      import Mobius.Validations.ActionValidations
+
+      alias Mobius.Actions
+
+      resource = __MODULE__ |> Module.split() |> List.last()
+
+      Enum.each(endpoints, fn endpoint ->
+        name = endpoint.name
+        param_names = Actions.get_arguments(endpoint)
+        params_keyword = Actions.get_arguments_keyword(endpoint)
+
+        def unquote(name)(unquote_splicing(param_names)) do
+          Actions.execute(
+            unquote(Macro.escape(endpoint)),
+            unquote(params_keyword),
+            unquote(resource)
+          )
+        end
+      end)
+    end
+  end
+
+  @spec execute(Endpoint.t(), Keyword.t(any()), atom() | binary()) :: any()
+  def execute(%Endpoint{} = endpoint, params, resource) do
+    rest_module = Module.concat([:Mobius, :Rest, resource])
+
+    validators = get_validators(endpoint)
+
+    case ActionValidations.validate_params(Keyword.get(params, :params, %{}), validators) do
+      :ok ->
+        param_values = Enum.map(params, fn {_name, value} -> value end)
+        apply(rest_module, endpoint.name, [Bot.get_client!() | param_values])
+
+      {:error, errors} ->
+        {:error, errors}
+    end
+  end
+
+  @spec get_arguments(Endpoint.t()) :: [Macro.input()]
+  def get_arguments(%Endpoint{} = endpoint) do
+    endpoint
+    |> get_arguments_names()
+    |> Enum.map(&Macro.var(&1, __MODULE__))
+  end
+
+  @spec get_arguments_keyword(Endpoint.t()) :: Keyword.t(Macro.input())
+  def get_arguments_keyword(%Endpoint{} = endpoint) do
+    endpoint
+    |> get_arguments_names()
+    |> Enum.map(fn argument -> {argument, Macro.var(argument, __MODULE__)} end)
+  end
+
+  defp get_arguments_names(%Endpoint{opts: _} = endpoint), do: endpoint.params ++ [:params]
+  defp get_arguments_names(%Endpoint{} = endpoint), do: endpoint.params
+
+  defp get_validators(%Endpoint{} = endpoint) do
+    Enum.map(endpoint.opts, fn
+      {name, :snowflake} -> ActionValidations.snowflake_validator(name)
+      {name, :integer} -> ActionValidations.integer_validator(name)
+      {name, {:integer, opts}} -> get_integer_range_validator(name, opts)
+    end)
+  end
+
+  defp get_integer_range_validator(name, opts) do
+    min = Keyword.fetch!(opts, :min)
+    max = Keyword.fetch!(opts, :max)
+
+    if min != nil and max != nil do
+      ActionValidations.integer_range_validator(name, min, max)
+    else
+      ActionValidations.integer_validator(name)
+    end
+  end
+end

--- a/lib/mobius/actions/message.ex
+++ b/lib/mobius/actions/message.ex
@@ -5,10 +5,16 @@ defmodule Mobius.Actions.Message do
 
   import Mobius.Validations.ActionValidations
 
+  alias Mobius.Actions
   alias Mobius.Models.Message
+  alias Mobius.Models.Snowflake
   alias Mobius.Rest
   alias Mobius.Rest.Client
   alias Mobius.Services.Bot
+
+  require Actions
+
+  Actions.setup_actions(Mobius.Endpoint.Message.endpoints())
 
   @type file :: Rest.Message.file()
   @type message_body :: Rest.Message.message_body()
@@ -73,23 +79,6 @@ defmodule Mobius.Actions.Message do
 
       true ->
         Rest.Message.send_message(Bot.get_client!(), channel_id, body)
-    end
-  end
-
-  def list_messages(channel_id, params) do
-    # TODO: Validate permissions
-    # TODO: Make sure the cannel exists (requires a cache)
-
-    validators = [
-      integer_range_validator(:limit, 1, 100),
-      snowflake_validator(:around),
-      snowflake_validator(:before),
-      snowflake_validator(:after)
-    ]
-
-    case validate_params(params, validators) do
-      :ok -> Rest.Message.list_messages(Bot.get_client!(), channel_id, params)
-      {:error, errors} -> {:error, errors}
     end
   end
 end

--- a/lib/mobius/endpoint.ex
+++ b/lib/mobius/endpoint.ex
@@ -1,0 +1,25 @@
+defmodule Mobius.Endpoint do
+  @moduledoc """
+  An endpoint that can be used to interact with Discord
+
+  The attributes of an endpoint are the following:
+  - name: The name of the endpoint. This will correspond to the name of the
+  exposed by Mobius to query this endpoint.
+  - url: The url at which Discord exposes the endpoint.
+  - method: The HTTP method to use when sending requests to Discord.
+  - params: The list of query parameters the endpoint accepts.
+  - opts: The options that the endpoint accpets. These generaly correspond to
+  the HTTP request's body.
+  """
+
+  @enforce_keys ~w(name url method params)a
+  defstruct [:name, :url, :method, :params, :opts]
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          url: String.t(),
+          method: :get | :post,
+          params: [atom()],
+          opts: map()
+        }
+end

--- a/lib/mobius/endpoint.ex
+++ b/lib/mobius/endpoint.ex
@@ -8,7 +8,7 @@ defmodule Mobius.Endpoint do
   - url: The url at which Discord exposes the endpoint.
   - method: The HTTP method to use when sending requests to Discord.
   - params: The list of query parameters the endpoint accepts.
-  - opts: The options that the endpoint accpets. These generaly correspond to
+  - opts: The options that the endpoint accepts. These generally correspond to
   the HTTP request's body.
   """
 

--- a/lib/mobius/endpoints/message.ex
+++ b/lib/mobius/endpoints/message.ex
@@ -1,0 +1,22 @@
+defmodule Mobius.Endpoint.Message do
+  @moduledoc false
+
+  alias Mobius.Endpoint
+
+  @spec endpoints :: [Mobius.Endpoint.t()]
+  def endpoints,
+    do: [
+      %Endpoint{
+        name: :list_messages,
+        url: "/channels/:channel_id/messages",
+        method: :get,
+        params: [:channel_id],
+        opts: %{
+          around: :snowflake,
+          before: :snowflake,
+          after: :snowflake,
+          limit: {:integer, [min: 1, max: 100]}
+        }
+      }
+    ]
+end


### PR DESCRIPTION
Adds the `Endpoint` module and the action generator. In the future, this should help streamline the implementation of new endpoints, making development and maintenance much easier.