### PR TITLE
refactor: Make action validators take values directly

### DIFF
--- a/lib/mobius/actions.ex
+++ b/lib/mobius/actions.ex
@@ -68,22 +68,8 @@ defmodule Mobius.Actions do
     |> Enum.map(fn argument -> {argument, Macro.var(argument, __MODULE__)} end)
   end
 
+  @spec get_validators(Endpoint.t()) :: [{:atom, ActionValidations.validator()}]
   defp get_validators(%Endpoint{} = endpoint) do
-    Enum.map(endpoint.opts, fn
-      {name, :snowflake} -> ActionValidations.snowflake_validator(name)
-      {name, :integer} -> ActionValidations.integer_validator(name)
-      {name, {:integer, opts}} -> get_integer_range_validator(name, opts)
-    end)
-  end
-
-  defp get_integer_range_validator(name, opts) do
-    min = Keyword.fetch!(opts, :min)
-    max = Keyword.fetch!(opts, :max)
-
-    if min != nil and max != nil do
-      ActionValidations.integer_range_validator(name, min, max)
-    else
-      ActionValidations.integer_validator(name)
-    end
+    Enum.map(endpoint.opts, fn {name, type} -> {name, ActionValidations.get_validator(type)} end)
   end
 end

--- a/lib/mobius/actions/channel.ex
+++ b/lib/mobius/actions/channel.ex
@@ -37,12 +37,12 @@ defmodule Mobius.Actions.Channel do
     # TODO validate permissions
 
     validators = [
-      string_length_validator(:name, 2, 100),
-      &validate_channel_type/1,
-      string_length_validator(:topic, 0, 1024),
-      integer_range_validator(:rate_limit_per_user, 0, 21_600),
-      integer_range_validator(:bitrate, 8000, 96_000),
-      integer_range_validator(:user_limit, 0, 99)
+      {:name, string_length_validator(2, 100)},
+      {:type, &validate_channel_type/1},
+      {:topic, string_length_validator(0, 1024)},
+      {:rate_limit_per_user, integer_range_validator(0, 21_600)},
+      {:bitrate, integer_range_validator(8000, 96_000)},
+      {:user_limit, integer_range_validator(0, 99)}
     ]
 
     case validate_params(params, validators) do
@@ -68,10 +68,8 @@ defmodule Mobius.Actions.Channel do
   # TODO validate permissions
   def delete_channel(channel_id), do: Rest.Channel.delete_channel(Bot.get_client!(), channel_id)
 
-  defp validate_channel_type(%{type: type}) when type in [:guild_text, :guild_news], do: :ok
+  defp validate_channel_type(type) when type in [:guild_text, :guild_news], do: :ok
 
-  defp validate_channel_type(%{type: _type}),
-    do: {:error, "Channel type can only be converted to text or news"}
-
-  defp validate_channel_type(_params), do: :ok
+  defp validate_channel_type(type),
+    do: {:error, "to be either :guild_text or :guild_news, got #{type}"}
 end

--- a/lib/mobius/endpoint.ex
+++ b/lib/mobius/endpoint.ex
@@ -15,6 +15,8 @@ defmodule Mobius.Endpoint do
   - list_response?: Whether or not the request returns a list of entities.
   """
 
+  alias Mobius.Validations.ActionValidations
+
   @enforce_keys ~w(name url method params)a
   defstruct [:name, :url, :method, :params, :opts, :model, :list_response?]
 
@@ -23,7 +25,7 @@ defmodule Mobius.Endpoint do
           url: String.t(),
           method: :get | :post,
           params: [atom()],
-          opts: map() | nil,
+          opts: %{atom() => ActionValidations.validator_type()} | nil,
           model: atom() | nil,
           list_response?: boolean() | nil
         }

--- a/test/mobius/actions/channel_test.exs
+++ b/test/mobius/actions/channel_test.exs
@@ -58,7 +58,7 @@ defmodule Mobius.Actions.ChannelTest do
 
     test "returns an error if the channel type is in the allowed list", ctx do
       {:error, errors} = Channel.edit_channel(ctx.channel_id, %{type: :some_invalid_type})
-      assert_has_error(errors, "can only be converted to text or news")
+      assert_has_error(errors, "to be either :guild_text or :guild_news")
     end
 
     test "returns an error if the channel topic length is outside the allowed range", ctx do

--- a/test/mobius/validations/actions_validations_test.exs
+++ b/test/mobius/validations/actions_validations_test.exs
@@ -10,33 +10,29 @@ defmodule Mobius.Validations.ActionValidationsTest do
     setup do
       min = 2
       max = 4
-      validator = ActionValidations.string_length_validator(:foo, min, max)
+      validator = ActionValidations.string_length_validator(min, max)
 
       [min: min, max: max, validator: validator]
     end
 
     test "returns an error when provided a non-string input", ctx do
-      {:error, error} = ctx.validator.(%{foo: :bar})
+      {:error, error} = ctx.validator.(:bar)
 
-      assert error =~ "Expected foo to be a string"
+      assert error =~ "be a string"
     end
 
     test "returns an error when provided string length is outside allowed range", ctx do
-      error_message = "Expected foo to contain between #{ctx.min} and #{ctx.max} characters"
+      error_message = "contain between #{ctx.min} and #{ctx.max} characters"
 
-      {:error, error} = ctx.validator.(%{foo: random_text(ctx.min - 1)})
+      {:error, error} = ctx.validator.(random_text(ctx.min - 1))
       assert error =~ error_message
 
-      {:error, error} = ctx.validator.(%{foo: random_text(ctx.max + 1)})
+      {:error, error} = ctx.validator.(random_text(ctx.max + 1))
       assert error =~ error_message
     end
 
     test "returns :ok when provided string length is inside the allowed range", ctx do
-      assert :ok = ctx.validator.(%{foo: random_text(ctx.max - 1)})
-    end
-
-    test "returns :ok when the key is not in the provided input", ctx do
-      assert :ok = ctx.validator.(%{})
+      assert :ok = ctx.validator.(random_text(ctx.max - 1))
     end
   end
 
@@ -44,33 +40,29 @@ defmodule Mobius.Validations.ActionValidationsTest do
     setup do
       min = 2
       max = 4
-      validator = ActionValidations.integer_range_validator(:foo, min, max)
+      validator = ActionValidations.integer_range_validator(min, max)
 
       [min: min, max: max, validator: validator]
     end
 
     test "returns an error when provided a non-integer input", ctx do
-      {:error, error} = ctx.validator.(%{foo: :bar})
+      {:error, error} = ctx.validator.(:bar)
 
-      assert error =~ "Expected foo to be an integer"
+      assert error =~ "be an integer"
     end
 
     test "returns an error when provided integer is outside allowed range", ctx do
-      error_message = "Expected foo to be between #{ctx.min} and #{ctx.max}"
+      error_message = "be between #{ctx.min} and #{ctx.max}"
 
-      {:error, error} = ctx.validator.(%{foo: ctx.min - 1})
+      {:error, error} = ctx.validator.(ctx.min - 1)
       assert error =~ error_message
 
-      {:error, error} = ctx.validator.(%{foo: ctx.max + 1})
+      {:error, error} = ctx.validator.(ctx.max + 1)
       assert error =~ error_message
     end
 
     test "returns :ok when provided integer is inside the allowed range", ctx do
-      assert :ok = ctx.validator.(%{foo: ctx.max - 1})
-    end
-
-    test "returns :ok when the key is not in the provided input", ctx do
-      assert :ok = ctx.validator.(%{})
+      assert :ok = ctx.validator.(ctx.max - 1)
     end
   end
 
@@ -79,9 +71,13 @@ defmodule Mobius.Validations.ActionValidationsTest do
       validator1 = fn _ -> {:error, "error 1"} end
       validator2 = fn _ -> {:error, "error 2"} end
 
-      {:error, errors} = ActionValidations.validate_params(%{}, [validator1, validator2])
+      {:error, errors} =
+        ActionValidations.validate_params(%{foo: :foo, bar: :bar}, [
+          {:foo, validator1},
+          {:bar, validator2}
+        ])
 
-      assert_list_unordered(errors, ["error 1", "error 2"])
+      assert_list_unordered(errors, ["Expected bar to error 2", "Expected foo to error 1"])
     end
 
     test "returns :ok if no validator returns an error" do


### PR DESCRIPTION
Refactors the action validators to receive the value to validate directly instead of extracting it from the map of options.

This will make it far easier to implement a `list_validator`, which we will need for future endpoints.