### PR TITLE
feat: Validate types of all action parameters

### DIFF
--- a/lib/mobius/actions/channel.ex
+++ b/lib/mobius/actions/channel.ex
@@ -18,14 +18,14 @@ defmodule Mobius.Actions.Channel do
       name: :get_channel,
       url: "/channels/:channel_id",
       method: :get,
-      params: [:channel_id],
+      params: [{:channel_id, :snowflake}],
       model: Mobius.Models.Channel
     },
     %Endpoint{
       name: :edit_channel,
       url: "/channels/:channel_id",
       method: :patch,
-      params: [:channel_id],
+      params: [{:channel_id, :snowflake}],
       opts: %{
         name: {:string, [min: 2, max: 100]},
         type: {__MODULE__, :validate_channel_type},
@@ -40,7 +40,7 @@ defmodule Mobius.Actions.Channel do
       name: :delete_channel,
       url: "/channels/:channel_id",
       method: :delete,
-      params: [:channel_id],
+      params: [{:channel_id, :snowflake}],
       model: Mobius.Models.Channel
     }
   ])

--- a/lib/mobius/actions/message.ex
+++ b/lib/mobius/actions/message.ex
@@ -20,7 +20,7 @@ defmodule Mobius.Actions.Message do
       name: :list_messages,
       url: "/channels/:channel_id/messages",
       method: :get,
-      params: [:channel_id],
+      params: [{:channel_id, :snowflake}],
       opts: %{
         around: :snowflake,
         before: :snowflake,

--- a/lib/mobius/endpoint.ex
+++ b/lib/mobius/endpoint.ex
@@ -24,13 +24,20 @@ defmodule Mobius.Endpoint do
           name: atom(),
           url: String.t(),
           method: :get | :post | :patch | :delete,
-          params: [atom()],
+          params: [{atom(), ActionValidations.validator_type()}],
           opts: %{atom() => ActionValidations.validator_type()} | nil,
           model: atom() | nil,
           list_response?: boolean() | nil
         }
 
   @spec get_arguments_names(t()) :: [atom()]
-  def get_arguments_names(%__MODULE__{opts: nil} = endpoint), do: endpoint.params
-  def get_arguments_names(%__MODULE__{} = endpoint), do: endpoint.params ++ [:params]
+  def get_arguments_names(%__MODULE__{} = endpoint) do
+    params_names = Enum.map(endpoint.params, fn {name, _type} -> name end)
+
+    if endpoint.opts == nil do
+      params_names
+    else
+      params_names ++ [:params]
+    end
+  end
 end

--- a/lib/mobius/validations/action_validations.ex
+++ b/lib/mobius/validations/action_validations.ex
@@ -73,7 +73,7 @@ defmodule Mobius.Validations.ActionValidations do
         val = params[param_name]
 
         if val != nil do
-          case validator.(params[param_name]) do
+          case validator.(val) do
             :ok -> errors
             {:error, error} -> ["Expected #{param_name} to #{error}" | errors]
           end

--- a/lib/mobius/validations/action_validations.ex
+++ b/lib/mobius/validations/action_validations.ex
@@ -66,11 +66,13 @@ defmodule Mobius.Validations.ActionValidations do
     end
   end
 
-  @spec validate_params(map(), [{atom(), validator()}]) :: :ok | {:error, [String.t()]}
-  def validate_params(params, validators) do
+  @spec validate_args(Access.t(), [{atom(), validator()}]) :: :ok | {:error, [String.t()]}
+  def validate_args(params, validators) do
     errors =
       Enum.reduce(validators, [], fn {param_name, validator}, errors ->
-        if Map.has_key?(params, param_name) do
+        val = params[param_name]
+
+        if val != nil do
           case validator.(params[param_name]) do
             :ok -> errors
             {:error, error} -> ["Expected #{param_name} to #{error}" | errors]

--- a/test/mobius/actions/channel_test.exs
+++ b/test/mobius/actions/channel_test.exs
@@ -26,6 +26,11 @@ defmodule Mobius.Actions.ChannelTest do
       [channel_id: channel_id, raw_channel: raw]
     end
 
+    test "returns an error if channel_id is not a snowflake" do
+      {:error, errors} = Channel.get_channel(:not_a_snowflake)
+      assert_has_error(errors, "Expected channel_id to be a snowflake")
+    end
+
     test "returns the channel if successful", ctx do
       {:ok, channel} = Channel.get_channel(ctx.channel_id)
       assert channel == Models.Channel.parse(ctx.raw_channel)
@@ -97,6 +102,11 @@ defmodule Mobius.Actions.ChannelTest do
       {:error, errors} = Channel.edit_channel(ctx.channel_id, %{user_limit: 100})
       assert_has_error(errors, error_message)
     end
+
+    test "returns an error if channel_id is not a snowflake" do
+      {:error, errors} = Channel.edit_channel(:not_a_snowflake, %{})
+      assert_has_error(errors, "Expected channel_id to be a snowflake")
+    end
   end
 
   describe "delete_channel/1" do
@@ -111,6 +121,11 @@ defmodule Mobius.Actions.ChannelTest do
     test "returns the channel if successful", ctx do
       {:ok, channel} = Channel.delete_channel(ctx.channel_id)
       assert channel == Models.Channel.parse(ctx.raw_channel)
+    end
+
+    test "returns an error if channel_id is not a snowflake" do
+      {:error, errors} = Channel.delete_channel(:not_a_snowflake)
+      assert_has_error(errors, "Expected channel_id to be a snowflake")
     end
   end
 end

--- a/test/mobius/actions/message_test.exs
+++ b/test/mobius/actions/message_test.exs
@@ -91,6 +91,11 @@ defmodule Mobius.Actions.MessageTest do
       assert_has_error(errors, "Expected after to be a snowflake")
     end
 
+    test "returns an error if channel id is not a snowflake" do
+      {:error, errors} = Message.list_messages(:not_a_snowflake, %{})
+      assert_has_error(errors, "Expected channel_id to be a snowflake")
+    end
+
     test "returns the list of messages", ctx do
       {:ok, messages} = Message.list_messages(ctx.channel_id, %{})
       assert messages == [Models.Message.parse(ctx.raw_message)]

--- a/test/mobius/validations/actions_validations_test.exs
+++ b/test/mobius/validations/actions_validations_test.exs
@@ -66,13 +66,13 @@ defmodule Mobius.Validations.ActionValidationsTest do
     end
   end
 
-  describe "validate_params/2" do
+  describe "validate_args/2" do
     test "returns all errors returned by the validators" do
       validator1 = fn _ -> {:error, "error 1"} end
       validator2 = fn _ -> {:error, "error 2"} end
 
       {:error, errors} =
-        ActionValidations.validate_params(%{foo: :foo, bar: :bar}, [
+        ActionValidations.validate_args(%{foo: :foo, bar: :bar}, [
           {:foo, validator1},
           {:bar, validator2}
         ])
@@ -81,7 +81,7 @@ defmodule Mobius.Validations.ActionValidationsTest do
     end
 
     test "returns :ok if no validator returns an error" do
-      assert :ok = ActionValidations.validate_params(%{}, [])
+      assert :ok = ActionValidations.validate_args(%{}, [])
     end
   end
 end


### PR DESCRIPTION
Uses `ActionValidations` to validate the types of all action parameters.