### PR TITLE
feat: Add support for documentation generation in actions

### DIFF
--- a/lib/mobius/actions.ex
+++ b/lib/mobius/actions.ex
@@ -30,7 +30,9 @@ defmodule Mobius.Actions do
         name = endpoint.name
         param_names = Actions.get_arguments(endpoint)
         params_keyword = Actions.get_arguments_keyword(endpoint)
+        docs = Actions.get_docs(endpoint)
 
+        @doc docs
         def unquote(name)(unquote_splicing(param_names)) do
           Actions.execute(
             unquote(Macro.escape(endpoint)),
@@ -41,7 +43,7 @@ defmodule Mobius.Actions do
     end
   end
 
-  @spec execute(Endpoint.t(), keyword()) :: any()
+  @spec execute(Endpoint.t(), keyword()) :: Mobius.Rest.Client.result(any())
   def execute(%Endpoint{} = endpoint, params) do
     validators = get_validators(endpoint)
 
@@ -68,6 +70,18 @@ defmodule Mobius.Actions do
     endpoint
     |> Endpoint.get_arguments_names()
     |> Enum.map(fn argument -> {argument, Macro.var(argument, __MODULE__)} end)
+  end
+
+  @spec get_docs(Endpoint.t()) :: String.t()
+  def get_docs(%Endpoint{} = endpoint) do
+    """
+    #{endpoint.doc}
+
+    ## Documentation
+
+    Relevant documentation:
+    #{endpoint.discord_doc_url}
+    """
   end
 
   @spec get_validators(Endpoint.t()) :: [{:atom, ActionValidations.validator()}]

--- a/lib/mobius/actions/channel.ex
+++ b/lib/mobius/actions/channel.ex
@@ -19,6 +19,15 @@ defmodule Mobius.Actions.Channel do
       url: "/channels/:channel_id",
       method: :get,
       params: [{:channel_id, :snowflake}],
+      discord_doc_url: "https://discord.com/developers/docs/resources/channel#get-channel",
+      doc: """
+      Fetch a channel
+
+      ## Example
+
+          iex> get_channel("123456789")
+          {:ok, %Mobius.Models.Channel{} = channel}
+      """,
       model: Mobius.Models.Channel
     },
     %Endpoint{
@@ -34,6 +43,28 @@ defmodule Mobius.Actions.Channel do
         bitrate: {:integer, [min: 8000, max: 96_000]},
         user_limit: {:integer, [min: 0, max: 99]}
       },
+      discord_doc_url: "https://discord.com/developers/docs/resources/channel#modify-channel",
+      doc: """
+      Edits a channel
+
+      This function accepts the following options:
+      - name: The name of the channel (between 2 and 100 characters).
+      - type: The type of the channel. See `t:Mobius.Models.Channel.type/0` for
+      the list of available types. Can only be converted from "text" to "news"
+      and vice-versa, and only in guilds with the "NEWS" feature.
+      - topic: The topic of the channel (between 0 and 1024 characters).
+      - rate_limit_per_user: The number of seconds users have to wait between
+      each sent message (between 0 and 21 600).
+      - bitrate: The bitrate of the channel (voice channels only)
+      (between 8000 and 96 000).
+      - user_limit: The maximum number of users that can join the cannel (voice
+      channels only) (between 0 and 99, 0 means unlimited).
+
+      ## Example
+
+          iex> edit_channel("123456789", name: "my new channel name")
+          {:ok, %Mobius.Models.Channel{name: "my new channel name"} = channel}
+      """,
       model: Mobius.Models.Channel
     },
     %Endpoint{
@@ -41,6 +72,16 @@ defmodule Mobius.Actions.Channel do
       url: "/channels/:channel_id",
       method: :delete,
       params: [{:channel_id, :snowflake}],
+      discord_doc_url:
+        "https://discord.com/developers/docs/resources/channel#deleteclose-channel",
+      doc: """
+      Delete a channel
+
+      ## Example
+
+          iex> delete_channel("123456789")
+          {:ok, %Mobius.Models.Channel{} = channel}
+      """,
       model: Mobius.Models.Channel
     }
   ])

--- a/lib/mobius/actions/message.ex
+++ b/lib/mobius/actions/message.ex
@@ -28,6 +28,24 @@ defmodule Mobius.Actions.Message do
         limit: {:integer, [min: 1, max: 100]}
       },
       list_response?: true,
+      discord_doc_url:
+        "https://discord.com/developers/docs/resources/channel#get-channel-messages",
+      doc: """
+      Fetches the list of messages in a channel
+
+      This function accepts the following options:
+      - around: The ID of a message that should be in the middle of the returned list
+      - before: The ID of a message that should be right after the last message in the returned list
+      - after: The ID of a message that should be right before the first message in the returned list
+      - limit: The number of messages to be fetched (between 1 and 100, defaults to 50)
+
+      `:around`, `:before` and `:after` are mutually exclusive.
+
+      ## Example
+
+          iex> list_messages("123456789", limit: 1)
+          {:ok, [%Mobius.Models.Message{} = message]}
+      """,
       model: Mobius.Models.Message
     }
   ])

--- a/lib/mobius/endpoint.ex
+++ b/lib/mobius/endpoint.ex
@@ -8,17 +8,31 @@ defmodule Mobius.Endpoint do
   - url: The url at which Discord exposes the endpoint.
   - method: The HTTP method to use when sending requests to Discord.
   - params: The list of query parameters the endpoint accepts.
-  - opts: The options that the endpoint accepts. These generally correspond to
-  the HTTP request's body.
+  - opts: The options that the endpoint accepts. These correspond to
+  the HTTP request's body for POST and PATCH requests or to optional query
+  parameters for GET requests.
   - model: The Mobius model HTTP responses should be parsed into. No model means
   that the request is not expected to return any data.
   - list_response?: Whether or not the request returns a list of entities.
+  - discord_doc_url: The URL for the official Discord documentation for this
+  endpoint.
+  - doc: The documentation of the function.
   """
 
   alias Mobius.Validations.ActionValidations
 
-  @enforce_keys ~w(name url method params)a
-  defstruct [:name, :url, :method, :params, :opts, :model, :list_response?]
+  @enforce_keys ~w(name url method params discord_doc_url doc)a
+  defstruct [
+    :name,
+    :url,
+    :method,
+    :params,
+    :opts,
+    :model,
+    :discord_doc_url,
+    :doc,
+    list_response?: false
+  ]
 
   @type t :: %__MODULE__{
           name: atom(),
@@ -27,7 +41,9 @@ defmodule Mobius.Endpoint do
           params: [{atom(), ActionValidations.validator_type()}],
           opts: %{atom() => ActionValidations.validator_type()} | nil,
           model: atom() | nil,
-          list_response?: boolean() | nil
+          discord_doc_url: String.t(),
+          doc: String.t(),
+          list_response?: boolean()
         }
 
   @spec get_arguments_names(t()) :: [atom()]

--- a/lib/mobius/services/bot.ex
+++ b/lib/mobius/services/bot.ex
@@ -54,7 +54,7 @@ defmodule Mobius.Services.Bot do
 
   This may raise a `KeyError` if this service isn't started yet
   """
-  @spec get_client!() :: Rest.Client.t()
+  @spec get_client!() :: Rest.Client.client()
   def get_client! do
     __MODULE__
     |> :persistent_term.get(%{})

--- a/test/mobius/actions/channel_test.exs
+++ b/test/mobius/actions/channel_test.exs
@@ -42,7 +42,11 @@ defmodule Mobius.Actions.ChannelTest do
       channel_id = random_snowflake()
       updated_raw = channel(id: channel_id, name: "new_name")
       url = Client.base_url() <> "/channels/#{channel_id}"
-      mock(fn %{method: :patch, url: ^url} -> json(updated_raw) end)
+
+      mock(fn %{method: :patch, url: ^url} ->
+        json(updated_raw)
+      end)
+
       [channel_id: channel_id, raw_updated_channel: updated_raw]
     end
 


### PR DESCRIPTION
Adds support for generating function documentation in the action generator. Documentations include a (mandatory) link to the official discord doc as well as an optional custom section.