### PR TITLE
feat: Implement the delete_own_reaction action

### DIFF
--- a/lib/mobius/actions/reaction.ex
+++ b/lib/mobius/actions/reaction.ex
@@ -3,10 +3,34 @@ defmodule Mobius.Actions.Reaction do
   Actions related to Discord reactions such as creating, removing and listing reactions.
   """
 
+  alias Mobius.Actions
+  alias Mobius.Endpoint
   alias Mobius.Models.Emoji
   alias Mobius.Models.Snowflake
   alias Mobius.Rest
   alias Mobius.Services.Bot
+
+  require Actions
+
+  Actions.setup_actions([
+    %Endpoint{
+      name: :delete_own_reaction,
+      url: "/channels/:channel_id/messages/:message_id/reactions/:emoji/@me",
+      method: :delete,
+      params: [{:emoji, :emoji}, {:channel_id, :snowflake}, {:message_id, :snowflake}],
+      discord_doc_url:
+        "https://discord.com/developers/docs/resources/channel#delete-own-reaction",
+      doc: """
+      Deletes one of your own reactions
+
+      ## Example
+
+          iex> emoji = %Mobius.Models.Emoji{name: "👌"}
+          ...> Mobius.Actions.Reactions.delete_own_reaction(emoji, "123456789", "987654321")
+          :ok
+      """
+    }
+  ])
 
   @doc """
   Add a reaction to a message

--- a/lib/mobius/validations/action_validations.ex
+++ b/lib/mobius/validations/action_validations.ex
@@ -9,6 +9,7 @@ defmodule Mobius.Validations.ActionValidations do
           | {:string, keyword()}
           | :snowflake
           | {atom(), atom()}
+          | :emoji
   @type validator :: (any() -> :ok | {:error, String.t()})
 
   @spec string_length_validator(non_neg_integer(), non_neg_integer()) ::
@@ -66,6 +67,14 @@ defmodule Mobius.Validations.ActionValidations do
     end
   end
 
+  @spec emoji_validator :: validator()
+  defp emoji_validator do
+    fn
+      %Mobius.Models.Emoji{} -> :ok
+      val -> {:error, "be an emoji, got #{inspect(val)}"}
+    end
+  end
+
   @spec validate_args(Access.t(), [{atom(), validator()}]) :: :ok | {:error, [String.t()]}
   def validate_args(params, validators) do
     errors =
@@ -96,6 +105,7 @@ defmodule Mobius.Validations.ActionValidations do
   def get_validator(:string), do: string_validator()
   def get_validator({:string, opts}), do: get_string_length_validator(opts)
   def get_validator({module, function}), do: fn val -> apply(module, function, [val]) end
+  def get_validator(:emoji), do: emoji_validator()
 
   defp length_validator(min, max) do
     fn

--- a/test/mobius/actions/reaction_test.exs
+++ b/test/mobius/actions/reaction_test.exs
@@ -3,6 +3,7 @@ defmodule Mobius.Actions.ReactionTest do
 
   import Mobius.Fixtures
   import Mobius.Generators
+  import Mobius.TestUtils
   import Tesla.Mock, only: [mock: 1]
 
   alias Mobius.Actions.Reaction
@@ -33,6 +34,41 @@ defmodule Mobius.Actions.ReactionTest do
 
     test "returns :ok if successful", ctx do
       :ok = Reaction.create_reaction(ctx.emoji, ctx.channel_id, ctx.message_id)
+    end
+  end
+
+  describe "delete_own_reaction/3" do
+    setup do
+      message_id = random_snowflake()
+      channel_id = random_snowflake()
+      emoji = Emoji.parse(emoji())
+
+      url =
+        Client.base_url() <>
+          "/channels/#{channel_id}/messages/#{message_id}/reactions/#{Emoji.get_identifier(emoji)}/@me"
+
+      mock(fn %{method: :delete, url: ^url} -> empty_response() end)
+
+      [message_id: message_id, channel_id: channel_id, emoji: emoji]
+    end
+
+    test "returns :ok if successful", ctx do
+      :ok = Reaction.delete_own_reaction(ctx.emoji, ctx.channel_id, ctx.message_id)
+    end
+
+    test "returns an error if emoji is not an emoji" do
+      {:error, errors} = Reaction.delete_own_reaction("", "", "")
+      assert_has_error(errors, "Expected emoji to be an emoji")
+    end
+
+    test "returns an error if channel_id is not a snowflake" do
+      {:error, errors} = Reaction.delete_own_reaction(%{}, :not_a_snowflake, "")
+      assert_has_error(errors, "Expected channel_id to be a snowflake")
+    end
+
+    test "returns an error if message_id is not a snowflake" do
+      {:error, errors} = Reaction.delete_own_reaction(%{}, "1", :not_a_snowflake)
+      assert_has_error(errors, "Expected message_id to be a snowflake")
     end
   end
 end


### PR DESCRIPTION
- Implements the `delete_own_reaction` action.
- Adds a simple argument preprocessor to actions. Right now it is only used to get the identifier from an emoji.
- Adds an emoji action validator

Part of #29 