### PR TITLE
feat: Implement the delete_reaction action

### DIFF
--- a/lib/mobius/actions/reaction.ex
+++ b/lib/mobius/actions/reaction.ex
@@ -29,6 +29,28 @@ defmodule Mobius.Actions.Reaction do
           ...> Mobius.Actions.Reactions.delete_own_reaction(emoji, "123456789", "987654321")
           :ok
       """
+    },
+    %Endpoint{
+      name: :delete_reaction,
+      url: "/channels/:channel_id/messages/:message_id/reactions/:emoji/:user_id",
+      method: :delete,
+      params: [
+        {:emoji, :emoji},
+        {:channel_id, :snowflake},
+        {:message_id, :snowflake},
+        {:user_id, :snowflake}
+      ],
+      discord_doc_url:
+        "https://discord.com/developers/docs/resources/channel#delete-user-reaction",
+      doc: """
+      Deletes another user's reaction
+
+      ## Example
+
+          iex> emoji = %Mobius.Models.Emoji{name: "👌"}
+          ...> Mobius.Actions.Reactions.delete_reaction(emoji, "123456789", "987654321", "5432167890")
+          :ok
+      """
     }
   ])
 

--- a/test/mobius/actions/reaction_test.exs
+++ b/test/mobius/actions/reaction_test.exs
@@ -71,4 +71,45 @@ defmodule Mobius.Actions.ReactionTest do
       assert_has_error(errors, "Expected message_id to be a snowflake")
     end
   end
+
+  describe "delete_reaction/4" do
+    setup do
+      message_id = random_snowflake()
+      channel_id = random_snowflake()
+      user_id = random_snowflake()
+      emoji = Emoji.parse(emoji())
+
+      url =
+        Client.base_url() <>
+          "/channels/#{channel_id}/messages/#{message_id}/reactions/#{Emoji.get_identifier(emoji)}/#{user_id}"
+
+      mock(fn %{method: :delete, url: ^url} -> empty_response() end)
+
+      [message_id: message_id, channel_id: channel_id, emoji: emoji, user_id: user_id]
+    end
+
+    test "returns :ok if successful", ctx do
+      :ok = Reaction.delete_reaction(ctx.emoji, ctx.channel_id, ctx.message_id, ctx.user_id)
+    end
+
+    test "returns an error if emoji is not an emoji" do
+      {:error, errors} = Reaction.delete_reaction("", "", "", "")
+      assert_has_error(errors, "Expected emoji to be an emoji")
+    end
+
+    test "returns an error if channel_id is not a snowflake" do
+      {:error, errors} = Reaction.delete_reaction(%{}, :not_a_snowflake, "", "")
+      assert_has_error(errors, "Expected channel_id to be a snowflake")
+    end
+
+    test "returns an error if message_id is not a snowflake" do
+      {:error, errors} = Reaction.delete_reaction(%{}, "1", :not_a_snowflake, "")
+      assert_has_error(errors, "Expected message_id to be a snowflake")
+    end
+
+    test "returns an error if user_id is not a snowflake" do
+      {:error, errors} = Reaction.delete_reaction(%{}, "1", "", :not_a_snowflake)
+      assert_has_error(errors, "Expected user_id to be a snowflake")
+    end
+  end
 end


### PR DESCRIPTION
Implements the `delete_reaction` action.

Part of #29 