### PR TITLE
refactor: Create a Model behaviour

### DIFF
--- a/lib/mobius/core/event.ex
+++ b/lib/mobius/core/event.ex
@@ -2,6 +2,7 @@ defmodule Mobius.Core.Event do
   @moduledoc false
 
   alias Mobius.Core.ShardInfo
+  alias Mobius.Model
   alias Mobius.Models
 
   @valid_names [
@@ -318,7 +319,7 @@ defmodule Mobius.Core.Event do
 
   defp add_field(map, _, _, _), do: map
 
-  defp parse_guilds(data), do: Models.Utils.parse_list(data, &Models.Guild.parse/1)
-  defp parse_emojis(data), do: Models.Utils.parse_list(data, &Models.Emoji.parse/1)
-  defp parse_snowflakes(data), do: Models.Utils.parse_list(data, &Models.Snowflake.parse/1)
+  defp parse_guilds(data), do: Model.parse_list(data, &Models.Guild.parse/1)
+  defp parse_emojis(data), do: Model.parse_list(data, &Models.Emoji.parse/1)
+  defp parse_snowflakes(data), do: Model.parse_list(data, &Models.Snowflake.parse/1)
 end

--- a/lib/mobius/model.ex
+++ b/lib/mobius/model.ex
@@ -1,7 +1,18 @@
-defmodule Mobius.Models.Utils do
+defmodule Mobius.Model do
   @moduledoc false
 
   alias Mobius.Core.Bitflags
+
+  @callback parse(any()) :: any() | nil
+
+  @spec parse(module(), any()) :: any()
+  def parse(implementation, data) do
+    implementation.parse(data)
+  end
+
+  @spec parse_list(any, (any -> output)) :: [output] | nil when output: var
+  def parse_list(list, parser) when is_list(list), do: Enum.map(list, parser)
+  def parse_list(_list, _parser), do: nil
 
   @doc """
   Adds a field to the struct with the value given by struct_key in the map
@@ -21,10 +32,6 @@ defmodule Mobius.Models.Utils do
 
     struct!(struct, [{struct_key, value}])
   end
-
-  @spec parse_list(any, (any -> output)) :: [output] | nil when output: var
-  def parse_list(list, parser) when is_list(list), do: Enum.map(list, parser)
-  def parse_list(_list, _parser), do: nil
 
   @doc "Parse strings of numbers into integer, returns nil for any other value"
   @spec parse_integer(any) :: integer | nil

--- a/lib/mobius/models/activity.ex
+++ b/lib/mobius/models/activity.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.Activity do
   https://discord.com/developers/docs/topics/gateway#activity-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :name,
@@ -58,6 +60,7 @@ defmodule Mobius.Models.Activity do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/application.ex
+++ b/lib/mobius/models/application.ex
@@ -6,11 +6,13 @@ defmodule Mobius.Models.Application do
   https://discord.com/developers/docs/topics/oauth2#application-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
   alias Mobius.Models.Team
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -43,6 +45,7 @@ defmodule Mobius.Models.Application do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/attachment.ex
+++ b/lib/mobius/models/attachment.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.Attachment do
   https://discord.com/developers/docs/resources/channel#attachment-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -31,6 +33,7 @@ defmodule Mobius.Models.Attachment do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/ban.ex
+++ b/lib/mobius/models/ban.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.Ban do
   https://discord.com/developers/docs/resources/guild#ban-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :reason,
@@ -21,6 +23,7 @@ defmodule Mobius.Models.Ban do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/channel.ex
+++ b/lib/mobius/models/channel.ex
@@ -6,12 +6,14 @@ defmodule Mobius.Models.Channel do
   https://discord.com/developers/docs/resources/channel#channel-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.PermissionsOverwrite
   alias Mobius.Models.Snowflake
   alias Mobius.Models.Timestamp
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -78,6 +80,7 @@ defmodule Mobius.Models.Channel do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/channel_mention.ex
+++ b/lib/mobius/models/channel_mention.ex
@@ -6,10 +6,12 @@ defmodule Mobius.Models.ChannelMention do
   https://discord.com/developers/docs/resources/channel#channel-mention-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Channel
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -26,6 +28,7 @@ defmodule Mobius.Models.ChannelMention do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/embed.ex
+++ b/lib/mobius/models/embed.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.Embed do
   https://discord.com/developers/docs/resources/channel#embed-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Timestamp
+
+  @behaviour Mobius.Model
 
   defstruct [
     :title,
@@ -51,6 +53,7 @@ defmodule Mobius.Models.Embed do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/embed/author.ex
+++ b/lib/mobius/models/embed/author.ex
@@ -6,7 +6,9 @@ defmodule Mobius.Models.Embed.Author do
   https://discord.com/developers/docs/resources/channel#embed-object-embed-author-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
+
+  @behaviour Mobius.Model
 
   defstruct [
     :name,
@@ -23,6 +25,7 @@ defmodule Mobius.Models.Embed.Author do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/embed/field.ex
+++ b/lib/mobius/models/embed/field.ex
@@ -6,7 +6,9 @@ defmodule Mobius.Models.Embed.Field do
   https://discord.com/developers/docs/resources/channel#embed-object-embed-field-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
+
+  @behaviour Mobius.Model
 
   defstruct [
     :name,
@@ -21,6 +23,7 @@ defmodule Mobius.Models.Embed.Field do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/embed/footer.ex
+++ b/lib/mobius/models/embed/footer.ex
@@ -6,7 +6,9 @@ defmodule Mobius.Models.Embed.Footer do
   https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
+
+  @behaviour Mobius.Model
 
   defstruct [
     :text,
@@ -21,6 +23,7 @@ defmodule Mobius.Models.Embed.Footer do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/embed/media.ex
+++ b/lib/mobius/models/embed/media.ex
@@ -10,7 +10,9 @@ defmodule Mobius.Models.Embed.Media do
   https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
+
+  @behaviour Mobius.Model
 
   defstruct [
     :url,
@@ -27,6 +29,7 @@ defmodule Mobius.Models.Embed.Media do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/embed/provider.ex
+++ b/lib/mobius/models/embed/provider.ex
@@ -6,7 +6,9 @@ defmodule Mobius.Models.Embed.Provider do
   https://discord.com/developers/docs/resources/channel#embed-object-embed-provider-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
+
+  @behaviour Mobius.Model
 
   defstruct [
     :name,
@@ -19,6 +21,7 @@ defmodule Mobius.Models.Embed.Provider do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/emoji.ex
+++ b/lib/mobius/models/emoji.ex
@@ -10,10 +10,12 @@ defmodule Mobius.Models.Emoji do
   https://discord.com/developers/docs/resources/emoji#emoji-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -38,6 +40,7 @@ defmodule Mobius.Models.Emoji do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/gateway_bot.ex
+++ b/lib/mobius/models/gateway_bot.ex
@@ -5,9 +5,11 @@ defmodule Mobius.Models.GatewayBot do
   Related documentation: https://discord.com/developers/docs/topics/gateway#get-gateway-bot
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.SessionStartLimit
+
+  @behaviour Mobius.Model
 
   defstruct [:url, :shards, :session_start_limit]
 
@@ -30,6 +32,7 @@ defmodule Mobius.Models.GatewayBot do
       iex> parse(%{"url" => "wss://something", "shards" => 1, "session_start_limit" => %{}})
       %GatewayBot{url: "wss://something", shards: 1, session_start_limit: %SessionStartLimit{}}
   """
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/guild.ex
+++ b/lib/mobius/models/guild.ex
@@ -6,8 +6,9 @@ defmodule Mobius.Models.Guild do
   https://discord.com/developers/docs/resources/guild#guild-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
+  alias Mobius.Model
   alias Mobius.Models.Channel
   alias Mobius.Models.Emoji
   alias Mobius.Models.Guild.WelcomeScreen
@@ -17,8 +18,9 @@ defmodule Mobius.Models.Guild do
   alias Mobius.Models.Role
   alias Mobius.Models.Snowflake
   alias Mobius.Models.Timestamp
-  alias Mobius.Models.Utils
   alias Mobius.Models.VoiceState
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -154,6 +156,7 @@ defmodule Mobius.Models.Guild do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}
@@ -239,10 +242,10 @@ defmodule Mobius.Models.Guild do
   defp parse_premium_tier(3), do: :tier_3
   defp parse_premium_tier(_), do: nil
 
-  defp parse_roles(roles), do: Utils.parse_list(roles, &Role.parse/1)
-  defp parse_emojis(emojis), do: Utils.parse_list(emojis, &Emoji.parse/1)
-  defp parse_voice_states(states), do: Utils.parse_list(states, &VoiceState.parse/1)
-  defp parse_members(members), do: Utils.parse_list(members, &Member.parse/1)
-  defp parse_channels(channels), do: Utils.parse_list(channels, &Channel.parse/1)
-  defp parse_presences(presences), do: Utils.parse_list(presences, &Presence.parse/1)
+  defp parse_roles(roles), do: Model.parse_list(roles, &Role.parse/1)
+  defp parse_emojis(emojis), do: Model.parse_list(emojis, &Emoji.parse/1)
+  defp parse_voice_states(states), do: Model.parse_list(states, &VoiceState.parse/1)
+  defp parse_members(members), do: Model.parse_list(members, &Member.parse/1)
+  defp parse_channels(channels), do: Model.parse_list(channels, &Channel.parse/1)
+  defp parse_presences(presences), do: Model.parse_list(presences, &Presence.parse/1)
 end

--- a/lib/mobius/models/guild/welcome_channel.ex
+++ b/lib/mobius/models/guild/welcome_channel.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.Guild.WelcomeChannel do
   https://discord.com/developers/docs/resources/guild#welcome-screen-object-welcome-screen-channel-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :channel_id,
@@ -25,6 +27,7 @@ defmodule Mobius.Models.Guild.WelcomeChannel do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/guild/welcome_screen.ex
+++ b/lib/mobius/models/guild/welcome_screen.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.Guild.WelcomeScreen do
   https://discord.com/developers/docs/resources/guild#welcome-screen-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Guild.WelcomeChannel
+
+  @behaviour Mobius.Model
 
   defstruct [
     :description,
@@ -21,6 +23,7 @@ defmodule Mobius.Models.Guild.WelcomeScreen do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/guild_preview.ex
+++ b/lib/mobius/models/guild_preview.ex
@@ -9,10 +9,12 @@ defmodule Mobius.Models.GuildPreview do
   https://discord.com/developers/docs/resources/guild#guild-preview-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Emoji
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -41,6 +43,7 @@ defmodule Mobius.Models.GuildPreview do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/guild_template.ex
+++ b/lib/mobius/models/guild_template.ex
@@ -6,12 +6,14 @@ defmodule Mobius.Models.GuildTemplate do
   https://discord.com/developers/docs/resources/template#template-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Guild
   alias Mobius.Models.Snowflake
   alias Mobius.Models.Timestamp
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :code,
@@ -42,6 +44,7 @@ defmodule Mobius.Models.GuildTemplate do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/guild_widget.ex
+++ b/lib/mobius/models/guild_widget.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.GuildWidget do
   https://discord.com/developers/docs/resources/guild#guild-widget-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :enabled,
@@ -21,6 +23,7 @@ defmodule Mobius.Models.GuildWidget do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/integration.ex
+++ b/lib/mobius/models/integration.ex
@@ -6,11 +6,13 @@ defmodule Mobius.Models.Integration do
   https://discord.com/developers/docs/resources/guild#integration-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
   alias Mobius.Models.Timestamp
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -52,6 +54,7 @@ defmodule Mobius.Models.Integration do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/integration/account.ex
+++ b/lib/mobius/models/integration/account.ex
@@ -6,7 +6,9 @@ defmodule Mobius.Models.Integration.Account do
   https://discord.com/developers/docs/resources/guild#integration-account-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -19,6 +21,7 @@ defmodule Mobius.Models.Integration.Account do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/integration/application.ex
+++ b/lib/mobius/models/integration/application.ex
@@ -6,10 +6,12 @@ defmodule Mobius.Models.Integration.Application do
   https://discord.com/developers/docs/resources/guild#integration-application-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -30,6 +32,7 @@ defmodule Mobius.Models.Integration.Application do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/invite.ex
+++ b/lib/mobius/models/invite.ex
@@ -9,12 +9,14 @@ defmodule Mobius.Models.Invite do
   https://discord.com/developers/docs/resources/invite#invite-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Channel
   alias Mobius.Models.Guild
   alias Mobius.Models.InviteMetadata
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :code,
@@ -43,6 +45,7 @@ defmodule Mobius.Models.Invite do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{metadata: parse_metadata(map)}

--- a/lib/mobius/models/invite_metadata.ex
+++ b/lib/mobius/models/invite_metadata.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.InviteMetadata do
   https://discord.com/developers/docs/resources/invite#invite-metadata-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Timestamp
+
+  @behaviour Mobius.Model
 
   defstruct [
     :uses,
@@ -27,6 +29,7 @@ defmodule Mobius.Models.InviteMetadata do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/member.ex
+++ b/lib/mobius/models/member.ex
@@ -6,11 +6,13 @@ defmodule Mobius.Models.Member do
   https://discord.com/developers/docs/resources/guild#guild-member-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
   alias Mobius.Models.Timestamp
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :user,
@@ -35,6 +37,7 @@ defmodule Mobius.Models.Member do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/message.ex
+++ b/lib/mobius/models/message.ex
@@ -6,7 +6,7 @@ defmodule Mobius.Models.Message do
   https://discord.com/developers/docs/resources/channel#message-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Attachment
   alias Mobius.Models.ChannelMention
@@ -20,6 +20,8 @@ defmodule Mobius.Models.Message do
   alias Mobius.Models.Sticker
   alias Mobius.Models.Timestamp
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -115,6 +117,7 @@ defmodule Mobius.Models.Message do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/message_activity.ex
+++ b/lib/mobius/models/message_activity.ex
@@ -6,7 +6,9 @@ defmodule Mobius.Models.MessageActivity do
   https://discord.com/developers/docs/resources/channel#message-object-message-activity-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
+
+  @behaviour Mobius.Model
 
   defstruct [
     :type,
@@ -21,6 +23,7 @@ defmodule Mobius.Models.MessageActivity do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/message_application.ex
+++ b/lib/mobius/models/message_application.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.MessageApplication do
   https://discord.com/developers/docs/resources/channel#message-object-message-application-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -27,6 +29,7 @@ defmodule Mobius.Models.MessageApplication do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/message_reference.ex
+++ b/lib/mobius/models/message_reference.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.MessageReference do
   https://discord.com/developers/docs/resources/channel#message-object-message-reference-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :message_id,
@@ -23,6 +25,7 @@ defmodule Mobius.Models.MessageReference do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/permissions.ex
+++ b/lib/mobius/models/permissions.ex
@@ -7,7 +7,9 @@ defmodule Mobius.Models.Permissions do
   """
 
   alias Mobius.Core.Bitflags
-  alias Mobius.Models.Utils
+  alias Mobius.Model
+
+  @behaviour Model
 
   # Order is important, use nil for missing bitflags
   @permissions [
@@ -88,9 +90,10 @@ defmodule Mobius.Models.Permissions do
   def all_permissions, do: MapSet.new(@permissions)
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: MapSet.t(permission()) | nil
   def parse(string) when is_binary(string) do
-    case Utils.parse_integer(string) do
+    case Model.parse_integer(string) do
       nil -> nil
       integer -> Bitflags.parse_bitflags(integer, @permissions)
     end

--- a/lib/mobius/models/permissions_overwrite.ex
+++ b/lib/mobius/models/permissions_overwrite.ex
@@ -6,10 +6,12 @@ defmodule Mobius.Models.PermissionsOverwrite do
   https://discord.com/developers/docs/resources/channel#overwrite-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Permissions
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -28,6 +30,7 @@ defmodule Mobius.Models.PermissionsOverwrite do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/presence.ex
+++ b/lib/mobius/models/presence.ex
@@ -6,10 +6,12 @@ defmodule Mobius.Models.Presence do
   https://discord.com/developers/docs/topics/gateway#presence-update
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Activity
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :user_id,
@@ -30,6 +32,7 @@ defmodule Mobius.Models.Presence do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{user_id: Snowflake.parse(map["user"]["id"])}

--- a/lib/mobius/models/reaction.ex
+++ b/lib/mobius/models/reaction.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.Reaction do
   https://discord.com/developers/docs/resources/channel#reaction-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Emoji
+
+  @behaviour Mobius.Model
 
   defstruct [
     :count,
@@ -23,6 +25,7 @@ defmodule Mobius.Models.Reaction do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/role.ex
+++ b/lib/mobius/models/role.ex
@@ -6,11 +6,13 @@ defmodule Mobius.Models.Role do
   https://discord.com/developers/docs/topics/permissions#role-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Permissions
   alias Mobius.Models.RoleTags
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -37,6 +39,7 @@ defmodule Mobius.Models.Role do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/role_tags.ex
+++ b/lib/mobius/models/role_tags.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.RoleTags do
   https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :bot_id,
@@ -35,6 +37,7 @@ defmodule Mobius.Models.RoleTags do
       iex> parse(%{"bot_id" => "123456", "integration_id" => nil, "premium_subscriber" => nil})
       %RoleTags{bot_id: 123456}
   """
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/session_start_limit.ex
+++ b/lib/mobius/models/session_start_limit.ex
@@ -5,7 +5,9 @@ defmodule Mobius.Models.SessionStartLimit do
   Related documentation: https://discord.com/developers/docs/topics/gateway#get-gateway-bot
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
+
+  @behaviour Mobius.Model
 
   defstruct [:total, :remaining, :reset_after, :max_concurrency]
 
@@ -29,6 +31,7 @@ defmodule Mobius.Models.SessionStartLimit do
       iex> parse(%{"total" => 10, "remaining" => 9, "reset_after" => 0, "max_concurrency" => 1})
       %SessionStartLimit{max_concurrency: 1, remaining: 9, reset_after: 0, total: 10}
   """
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/snowflake.ex
+++ b/lib/mobius/models/snowflake.ex
@@ -12,7 +12,9 @@ defmodule Mobius.Models.Snowflake do
 
   import Bitwise
 
-  alias Mobius.Models.Utils
+  alias Mobius.Model
+
+  @behaviour Mobius.Model
 
   @type t :: pos_integer()
 
@@ -23,8 +25,9 @@ defmodule Mobius.Models.Snowflake do
 
   Returns nil if the value isn't a string or isn't only a number
   """
+  @impl true
   @spec parse(any) :: t() | nil
-  def parse(value), do: Utils.parse_integer(value)
+  def parse(value), do: Model.parse_integer(value)
 
   @doc """
   Returns the timestamp part (in milliseconds) of the snowflake

--- a/lib/mobius/models/stage_instance.ex
+++ b/lib/mobius/models/stage_instance.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.StageInstance do
   https://discord.com/developers/docs/resources/stage-instance
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -25,6 +27,7 @@ defmodule Mobius.Models.StageInstance do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/sticker.ex
+++ b/lib/mobius/models/sticker.ex
@@ -6,9 +6,11 @@ defmodule Mobius.Models.Sticker do
   https://discord.com/developers/docs/resources/channel#message-object-message-sticker-structure
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -35,6 +37,7 @@ defmodule Mobius.Models.Sticker do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/team.ex
+++ b/lib/mobius/models/team.ex
@@ -6,10 +6,12 @@ defmodule Mobius.Models.Team do
   https://discord.com/developers/docs/topics/teams#data-models-team-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
   alias Mobius.Models.TeamMember
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -26,6 +28,7 @@ defmodule Mobius.Models.Team do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/team_member.ex
+++ b/lib/mobius/models/team_member.ex
@@ -6,10 +6,12 @@ defmodule Mobius.Models.TeamMember do
   https://discord.com/developers/docs/topics/teams#data-models-team-members-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :membership_state,
@@ -28,6 +30,7 @@ defmodule Mobius.Models.TeamMember do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/timestamp.ex
+++ b/lib/mobius/models/timestamp.ex
@@ -1,6 +1,8 @@
 defmodule Mobius.Models.Timestamp do
   @moduledoc false
 
+  @behaviour Mobius.Model
+
   @doc """
   Parse an ISO8601 datetime into a `t:DateTime.t()` or return nil if it was invalid
 
@@ -17,6 +19,7 @@ defmodule Mobius.Models.Timestamp do
       iex> parse(%{})
       nil
   """
+  @impl true
   @spec parse(String.t()) :: DateTime.t() | nil
   def parse(stamp) when is_binary(stamp) do
     case DateTime.from_iso8601(stamp) do

--- a/lib/mobius/models/user.ex
+++ b/lib/mobius/models/user.ex
@@ -5,9 +5,11 @@ defmodule Mobius.Models.User do
   Relevant documentation: https://discord.com/developers/docs/resources/user#user-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -87,6 +89,7 @@ defmodule Mobius.Models.User do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/voice_region.ex
+++ b/lib/mobius/models/voice_region.ex
@@ -6,7 +6,9 @@ defmodule Mobius.Models.VoiceRegion do
   https://discord.com/developers/docs/resources/voice#voice-region-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -27,6 +29,7 @@ defmodule Mobius.Models.VoiceRegion do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/voice_state.ex
+++ b/lib/mobius/models/voice_state.ex
@@ -6,11 +6,13 @@ defmodule Mobius.Models.VoiceState do
   https://discord.com/developers/docs/resources/voice#voice-state-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Member
   alias Mobius.Models.Snowflake
   alias Mobius.Models.Timestamp
+
+  @behaviour Mobius.Model
 
   defstruct [
     :guild_id,
@@ -45,6 +47,7 @@ defmodule Mobius.Models.VoiceState do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/models/webhook.ex
+++ b/lib/mobius/models/webhook.ex
@@ -6,10 +6,12 @@ defmodule Mobius.Models.Webhook do
   https://discord.com/developers/docs/resources/webhook#webhook-object
   """
 
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Snowflake
   alias Mobius.Models.User
+
+  @behaviour Mobius.Model
 
   defstruct [
     :id,
@@ -38,6 +40,7 @@ defmodule Mobius.Models.Webhook do
         }
 
   @doc "Parses the given term into a `t:t()` if possible; returns nil otherwise"
+  @impl true
   @spec parse(any) :: t() | nil
   def parse(map) when is_map(map) do
     %__MODULE__{}

--- a/lib/mobius/rest.ex
+++ b/lib/mobius/rest.ex
@@ -2,6 +2,7 @@ defmodule Mobius.Rest do
   @moduledoc false
 
   alias Mobius.Endpoint
+  alias Mobius.Model
   alias Mobius.Rest.Client
 
   @spec execute(Endpoint.t(), Client.client(), keyword()) :: Client.result(any())
@@ -23,11 +24,11 @@ defmodule Mobius.Rest do
 
       endpoint.list_response? ->
         Client.parse_response(tesla_response, fn entities ->
-          Enum.map(entities, &apply(endpoint.model, :parse, [&1]))
+          Enum.map(entities, &Model.parse(endpoint.model, &1))
         end)
 
       true ->
-        Client.parse_response(tesla_response, &apply(endpoint.model, :parse, [&1]))
+        Client.parse_response(tesla_response, &Model.parse(endpoint.model, &1))
     end
   end
 

--- a/test/mobius/core/event_test.exs
+++ b/test/mobius/core/event_test.exs
@@ -7,6 +7,7 @@ defmodule Mobius.Core.EventTest do
 
   alias Mobius.Core.Event
   alias Mobius.Core.ShardInfo
+  alias Mobius.Model
   alias Mobius.Models
 
   describe "parse_name/1" do
@@ -69,7 +70,7 @@ defmodule Mobius.Core.EventTest do
       |> assert_field(:v, data["v"])
       |> assert_field(:user, Models.User.parse(data["user"]))
       |> assert_field(:private_channels, data["private_channels"])
-      |> assert_field(:guilds, Models.Utils.parse_list(data["guilds"], &Models.Guild.parse/1))
+      |> assert_field(:guilds, Model.parse_list(data["guilds"], &Models.Guild.parse/1))
       |> assert_field(:session_id, data["session_id"])
       |> assert_field(:shard, ShardInfo.from_list(data["shard"]))
       |> assert_field(:application, Models.Application.parse(data["application"]))
@@ -162,7 +163,7 @@ defmodule Mobius.Core.EventTest do
 
       parsed
       |> assert_field(:guild_id, Models.Snowflake.parse(data["guild_id"]))
-      |> assert_field(:emojis, Models.Utils.parse_list(data["emojis"], &Models.Emoji.parse/1))
+      |> assert_field(:emojis, Model.parse_list(data["emojis"], &Models.Emoji.parse/1))
     end
 
     test "parses :guild_integrations_update" do
@@ -213,7 +214,7 @@ defmodule Mobius.Core.EventTest do
       |> assert_field(:guild_id, Models.Snowflake.parse(data["guild_id"]))
       |> assert_field(
         :roles,
-        Models.Utils.parse_list(data["roles"], &Models.Snowflake.parse/1)
+        Model.parse_list(data["roles"], &Models.Snowflake.parse/1)
       )
       |> assert_field(:user, Models.User.parse(data["user"]))
       |> assert_field(:nick, data["nick"])
@@ -344,7 +345,7 @@ defmodule Mobius.Core.EventTest do
       parsed = Event.parse_data(:message_delete_bulk, data)
 
       parsed
-      |> assert_field(:ids, Models.Utils.parse_list(data["ids"], &Models.Snowflake.parse/1))
+      |> assert_field(:ids, Model.parse_list(data["ids"], &Models.Snowflake.parse/1))
       |> assert_field(:channel_id, Models.Snowflake.parse(data["channel_id"]))
       |> assert_field(:guild_id, Models.Snowflake.parse(data["guild_id"]))
     end

--- a/test/mobius/models/channel_test.exs
+++ b/test/mobius/models/channel_test.exs
@@ -2,7 +2,7 @@ defmodule Mobius.Models.ChannelTest do
   use ExUnit.Case, async: true
 
   import Mobius.Generators
-  import Mobius.Models.Utils
+  import Mobius.Model
   import Mobius.TestUtils
 
   alias Mobius.Models.Channel

--- a/test/mobius/models/embed_test.exs
+++ b/test/mobius/models/embed_test.exs
@@ -4,6 +4,7 @@ defmodule Mobius.Models.EmbedTest do
   import Mobius.Generators
   import Mobius.TestUtils
 
+  alias Mobius.Model
   alias Mobius.Models.Embed
   alias Mobius.Models.Embed.Author
   alias Mobius.Models.Embed.Field
@@ -11,7 +12,6 @@ defmodule Mobius.Models.EmbedTest do
   alias Mobius.Models.Embed.Media
   alias Mobius.Models.Embed.Provider
   alias Mobius.Models.Timestamp
-  alias Mobius.Models.Utils
 
   describe "parse/1" do
     test "returns nil for non-maps" do
@@ -56,7 +56,7 @@ defmodule Mobius.Models.EmbedTest do
       |> assert_field(:video, Media.parse(map["video"]))
       |> assert_field(:provider, Provider.parse(map["provider"]))
       |> assert_field(:author, Author.parse(map["author"]))
-      |> assert_field(:fields, Utils.parse_list(map["fields"], &Field.parse/1))
+      |> assert_field(:fields, Model.parse_list(map["fields"], &Field.parse/1))
     end
   end
 end

--- a/test/mobius/models/emoji_test.exs
+++ b/test/mobius/models/emoji_test.exs
@@ -5,10 +5,10 @@ defmodule Mobius.Models.EmojiTest do
   import Mobius.Generators
   import Mobius.TestUtils
 
+  alias Mobius.Model
   alias Mobius.Models.Emoji
   alias Mobius.Models.Snowflake
   alias Mobius.Models.User
-  alias Mobius.Models.Utils
 
   describe "parse/1" do
     test "returns nil for non-maps" do
@@ -38,7 +38,7 @@ defmodule Mobius.Models.EmojiTest do
       |> Emoji.parse()
       |> assert_field(:id, Snowflake.parse(map["id"]))
       |> assert_field(:name, map["name"])
-      |> assert_field(:roles, Utils.parse_list(map["roles"], &Snowflake.parse/1))
+      |> assert_field(:roles, Model.parse_list(map["roles"], &Snowflake.parse/1))
       |> assert_field(:user, User.parse(map["user"]))
       |> assert_field(:require_colons, map["require_colons"])
       |> assert_field(:managed, map["managed"])

--- a/test/mobius/models/guild_preview_test.exs
+++ b/test/mobius/models/guild_preview_test.exs
@@ -5,10 +5,10 @@ defmodule Mobius.Models.GuildPreviewTest do
   import Mobius.Generators
   import Mobius.TestUtils
 
+  alias Mobius.Model
   alias Mobius.Models.Emoji
   alias Mobius.Models.GuildPreview
   alias Mobius.Models.Snowflake
-  alias Mobius.Models.Utils
 
   describe "parse/1" do
     test "returns nil for non-maps" do
@@ -54,7 +54,7 @@ defmodule Mobius.Models.GuildPreviewTest do
       |> assert_field(:icon, map["icon"])
       |> assert_field(:splash, map["splash"])
       |> assert_field(:discovery_splash, map["discovery_splash"])
-      |> assert_field(:emojis, Utils.parse_list(map["emojis"], &Emoji.parse/1))
+      |> assert_field(:emojis, Model.parse_list(map["emojis"], &Emoji.parse/1))
       |> assert_field(:features, map["features"])
       |> assert_field(:approximate_member_count, map["approximate_member_count"])
       |> assert_field(:approximate_presence_count, map["approximate_presence_count"])

--- a/test/mobius/models/guild_test.exs
+++ b/test/mobius/models/guild_test.exs
@@ -4,6 +4,7 @@ defmodule Mobius.Models.GuildTest do
   import Mobius.Generators
   import Mobius.TestUtils
 
+  alias Mobius.Model
   alias Mobius.Models.Channel
   alias Mobius.Models.Emoji
   alias Mobius.Models.Guild
@@ -13,7 +14,6 @@ defmodule Mobius.Models.GuildTest do
   alias Mobius.Models.Role
   alias Mobius.Models.Snowflake
   alias Mobius.Models.Timestamp
-  alias Mobius.Models.Utils
   alias Mobius.Models.VoiceState
 
   describe "parse/1" do
@@ -97,8 +97,8 @@ defmodule Mobius.Models.GuildTest do
       |> assert_field(:verification_level, :high)
       |> assert_field(:default_message_notifications, :only_mentions)
       |> assert_field(:explicit_content_filter, :members_without_roles)
-      |> assert_field(:roles, Utils.parse_list(map["roles"], &Role.parse/1))
-      |> assert_field(:emojis, Utils.parse_list(map["emojis"], &Emoji.parse/1))
+      |> assert_field(:roles, Model.parse_list(map["roles"], &Role.parse/1))
+      |> assert_field(:emojis, Model.parse_list(map["emojis"], &Emoji.parse/1))
       |> assert_field(:features, MapSet.new([:community, :welcome_screen_enabled]))
       |> assert_field(:mfa_level, :elevated)
       |> assert_field(:application_id, Snowflake.parse(map["application_id"]))
@@ -112,10 +112,10 @@ defmodule Mobius.Models.GuildTest do
       |> assert_field(:large, map["large"])
       |> assert_field(:unavailable, map["unavailable"])
       |> assert_field(:member_count, map["member_count"])
-      |> assert_field(:voice_states, Utils.parse_list(map["voice_states"], &VoiceState.parse/1))
-      |> assert_field(:members, Utils.parse_list(map["members"], &Member.parse/1))
-      |> assert_field(:channels, Utils.parse_list(map["channels"], &Channel.parse/1))
-      |> assert_field(:presences, Utils.parse_list(map["presences"], &Presence.parse/1))
+      |> assert_field(:voice_states, Model.parse_list(map["voice_states"], &VoiceState.parse/1))
+      |> assert_field(:members, Model.parse_list(map["members"], &Member.parse/1))
+      |> assert_field(:channels, Model.parse_list(map["channels"], &Channel.parse/1))
+      |> assert_field(:presences, Model.parse_list(map["presences"], &Presence.parse/1))
       |> assert_field(:max_presences, map["max_presences"])
       |> assert_field(:max_members, map["max_members"])
       |> assert_field(:vanity_url_code, map["vanity_url_code"])

--- a/test/mobius/models/member_test.exs
+++ b/test/mobius/models/member_test.exs
@@ -4,11 +4,11 @@ defmodule Mobius.Models.MemberTest do
   import Mobius.Generators
   import Mobius.TestUtils
 
+  alias Mobius.Model
   alias Mobius.Models.Member
   alias Mobius.Models.Snowflake
   alias Mobius.Models.Timestamp
   alias Mobius.Models.User
-  alias Mobius.Models.Utils
 
   describe "parse/1" do
     test "returns nil for non-maps" do
@@ -38,7 +38,7 @@ defmodule Mobius.Models.MemberTest do
       |> Member.parse()
       |> assert_field(:user, User.parse(map["user"]))
       |> assert_field(:nick, map["nick"])
-      |> assert_field(:roles, Utils.parse_list(map["roles"], &Snowflake.parse/1))
+      |> assert_field(:roles, Model.parse_list(map["roles"], &Snowflake.parse/1))
       |> assert_field(:joined_at, Timestamp.parse(map["joined_at"]))
       |> assert_field(:premium_since, Timestamp.parse(map["premium_since"]))
       |> assert_field(:deaf, map["deaf"])

--- a/test/mobius/models/message_test.exs
+++ b/test/mobius/models/message_test.exs
@@ -3,7 +3,7 @@ defmodule Mobius.Models.MessageTest do
 
   import Mobius.Generators
   import Mobius.TestUtils
-  import Mobius.Models.Utils
+  import Mobius.Model
 
   alias Mobius.Models.Attachment
   alias Mobius.Models.ChannelMention

--- a/test/mobius/models/presence_test.exs
+++ b/test/mobius/models/presence_test.exs
@@ -4,10 +4,10 @@ defmodule Mobius.Models.PresenceTest do
   import Mobius.Generators
   import Mobius.TestUtils
 
+  alias Mobius.Model
   alias Mobius.Models.Activity
   alias Mobius.Models.Presence
   alias Mobius.Models.Snowflake
-  alias Mobius.Models.Utils
 
   describe "parse/1" do
     test "returns nil for non-maps" do
@@ -35,7 +35,7 @@ defmodule Mobius.Models.PresenceTest do
       |> assert_field(:user_id, Snowflake.parse(map["user"]["id"]))
       |> assert_field(:guild_id, Snowflake.parse(map["guild_id"]))
       |> assert_field(:status, :online)
-      |> assert_field(:activities, Utils.parse_list(map["activities"], &Activity.parse/1))
+      |> assert_field(:activities, Model.parse_list(map["activities"], &Activity.parse/1))
       |> assert_field(:client_status, %{
         "desktop" => :idle,
         "mobile" => :dnd,

--- a/test/mobius/models/team_test.exs
+++ b/test/mobius/models/team_test.exs
@@ -4,10 +4,10 @@ defmodule Mobius.Models.TeamTest do
   import Mobius.Generators
   import Mobius.TestUtils
 
+  alias Mobius.Model
   alias Mobius.Models.Snowflake
   alias Mobius.Models.Team
   alias Mobius.Models.TeamMember
-  alias Mobius.Models.Utils
 
   describe "parse/1" do
     test "returns nil for non-maps" do
@@ -33,7 +33,7 @@ defmodule Mobius.Models.TeamTest do
       |> Team.parse()
       |> assert_field(:id, Snowflake.parse(map["id"]))
       |> assert_field(:icon, map["icon"])
-      |> assert_field(:members, Utils.parse_list(map["members"], &TeamMember.parse/1))
+      |> assert_field(:members, Model.parse_list(map["members"], &TeamMember.parse/1))
       |> assert_field(:owner_user_id, Snowflake.parse(map["owner_user_id"]))
     end
   end


### PR DESCRIPTION
- Renames `Mobius.Models.Utils` to `Mobius.Model`
- Adds a callback for the `parse/1` function
- Replace `apply/3` call with the new callback