### PR TITLE
feat: Implement the edit_message action

### DIFF
--- a/lib/mobius/actions.ex
+++ b/lib/mobius/actions.ex
@@ -122,7 +122,7 @@ defmodule Mobius.Actions do
   defp pre_process_param_value(_, value), do: value
 
   @spec check_bot_ready() :: :ok | {:error, String.t()}
-  defp check_bot_ready() do
+  defp check_bot_ready do
     if Bot.ready?() do
       :ok
     else

--- a/lib/mobius/actions.ex
+++ b/lib/mobius/actions.ex
@@ -48,15 +48,14 @@ defmodule Mobius.Actions do
   def execute(%Endpoint{} = endpoint, params) do
     validators = get_validators(endpoint)
 
-    path_params = params |> Keyword.get(:params, %{}) |> Keyword.new()
+    options = params |> Keyword.get(:options, %{}) |> Keyword.new()
 
-    case ActionValidations.validate_args(params ++ path_params, validators) do
-      :ok ->
-        processed_params = pre_process_params(endpoint, params)
-        Mobius.Rest.execute(endpoint, Bot.get_client!(), processed_params)
-
-      {:error, errors} ->
-        {:error, errors}
+    with :ok <- check_bot_ready(),
+         :ok <- ActionValidations.validate_args(params ++ options, validators),
+         :ok <-
+           ActionValidations.validate_constraints(params ++ options, endpoint.constraints) do
+      processed_params = pre_process_params(endpoint, params)
+      Mobius.Rest.execute(endpoint, Bot.get_client!(), processed_params)
     end
   end
 
@@ -121,4 +120,13 @@ defmodule Mobius.Actions do
     do: Emoji.get_identifier(emoji)
 
   defp pre_process_param_value(_, value), do: value
+
+  @spec check_bot_ready() :: :ok | {:error, String.t()}
+  defp check_bot_ready() do
+    if Bot.ready?() do
+      :ok
+    else
+      {:error, "The bot must be ready before using actions"}
+    end
+  end
 end

--- a/lib/mobius/actions/message.ex
+++ b/lib/mobius/actions/message.ex
@@ -64,6 +64,40 @@ defmodule Mobius.Actions.Message do
           {:ok, %Mobius.Models.Message{} = message}
       """,
       model: Mobius.Models.Message
+    },
+    %Endpoint{
+      name: :edit_message,
+      url: "/channels/:channel_id/messages/:message_id",
+      method: :patch,
+      params: [{:channel_id, :snowflake}, {:message_id, :snowflake}],
+      opts: %{
+        content: {:string, [max: 2000]},
+        embed: :any,
+        flags: :integer,
+        file: :any,
+        allowed_mentions: :any
+      },
+      constraints: [{:one_of, [:content, :embed, :file]}],
+      discord_doc_url: "https://discord.com/developers/docs/resources/channel#edit-message",
+      model: Mobius.Models.Message,
+      multipart?: true,
+      doc: """
+      Edits an exsting message
+
+      Only the original author of the message may edit the "content" and
+      "embeds" fields. Flags may be edited by anyone.
+
+      Be awarae that updating flags works as a complete replacement. This means
+      that if you want to add a new flag, you also need to set all existing
+      flags along with the new one.
+
+      Refer to `send_message/2` for more information on the message body format.
+
+      ## Example
+
+          iex> send_message(%{content: "Some content"}, channel_id)
+          {:ok, %Mobius.Models.Message{} = message}
+      """
     }
   ])
 

--- a/lib/mobius/actions/message.ex
+++ b/lib/mobius/actions/message.ex
@@ -77,17 +77,17 @@ defmodule Mobius.Actions.Message do
         file: :any,
         allowed_mentions: :any
       },
-      constraints: [{:one_of, [:content, :embed, :file]}],
+      constraints: [{:at_least_one_of, [:content, :embed, :file]}],
       discord_doc_url: "https://discord.com/developers/docs/resources/channel#edit-message",
       model: Mobius.Models.Message,
       multipart?: true,
       doc: """
-      Edits an exsting message
+      Edits an existing message
 
       Only the original author of the message may edit the "content" and
       "embeds" fields. Flags may be edited by anyone.
 
-      Be awarae that updating flags works as a complete replacement. This means
+      Be aware that updating flags works as a complete replacement. This means
       that if you want to add a new flag, you also need to set all existing
       flags along with the new one.
 

--- a/lib/mobius/endpoint.ex
+++ b/lib/mobius/endpoint.ex
@@ -19,7 +19,7 @@ defmodule Mobius.Endpoint do
   - doc: The documentation of the function.
   - multipart?: Whether the endpoint can contain multipart form data. If true,
   the endpoint has to have an option with the name `:file`.
-  - constraints: Additional contstraints for `:opts` that that involve
+  - constraints: Additional constraints for `:opts` that that involve
   contextual information about multiple options at a time.
   """
 

--- a/lib/mobius/endpoint.ex
+++ b/lib/mobius/endpoint.ex
@@ -17,6 +17,10 @@ defmodule Mobius.Endpoint do
   - discord_doc_url: The URL for the official Discord documentation for this
   endpoint.
   - doc: The documentation of the function.
+  - multipart?: Whether the endpoint can contain multipart form data. If true,
+  the endpoint has to have an option with the name `:file`.
+  - constraints: Additional contstraints for `:opts` that that involve
+  contextual information about multiple options at a time.
   """
 
   alias Mobius.Validations.ActionValidations
@@ -31,7 +35,9 @@ defmodule Mobius.Endpoint do
     :model,
     :discord_doc_url,
     :doc,
-    list_response?: false
+    list_response?: false,
+    constraints: [],
+    multipart?: false
   ]
 
   @type t :: %__MODULE__{
@@ -43,7 +49,9 @@ defmodule Mobius.Endpoint do
           model: atom() | nil,
           discord_doc_url: String.t(),
           doc: String.t(),
-          list_response?: boolean()
+          list_response?: boolean(),
+          constraints: [ActionValidations.constraint()],
+          multipart?: boolean()
         }
 
   @spec get_arguments_names(t()) :: [atom()]
@@ -53,7 +61,7 @@ defmodule Mobius.Endpoint do
     if endpoint.opts == nil do
       params_names
     else
-      params_names ++ [:params]
+      params_names ++ [:options]
     end
   end
 end

--- a/lib/mobius/validations/action_validations.ex
+++ b/lib/mobius/validations/action_validations.ex
@@ -1,16 +1,74 @@
 defmodule Mobius.Validations.ActionValidations do
-  @moduledoc false
+  @moduledoc """
+  Validation utilities for actions
+
+  ## Validator types
+
+  ### :any
+
+  Any value.
+
+  ### :string
+
+  Any string.
+
+  ### {:string, keyword()}
+
+  A string with options. The supported options are:
+  - min: The minimum length of the string. Defaults to 0.
+  - max: The maximum length of the string. Required.
+
+  ### :integer
+
+  Any integer.
+
+  ### {:integer, keyword()}
+
+  An integer with options. The supported options are:
+  - min: The minimum value of the integer. Required.
+  - max: The maximum value of the integer. Required.
+
+  ### :snowflake
+
+  Any snowflake.
+
+  ### {module(), atom()}
+
+  A custom validator. The first element must be a module name and the second one
+  a one-arity function in that module. The function will receive the option
+  value as its only argument.
+
+  ### :emoji
+
+  An emoji. Must be a `Mobius.Models.Emoji` struct.
+
+  ## Constraints
+
+  Contsraints are similar to validator in that they verify that some conditions
+  are met. The main difference between the two is that while validators operate
+  on a single parameter at a time, constraints can operate on multiple
+  parameters at a time.
+
+  Following is the list of available constraints.
+
+  ### {:one_of, [atom()]}
+
+  Verifies that at least one of the specified parameter was provided to the
+  action.
+  """
 
   @type validator_type ::
           :string
+          | {:string, keyword()}
           | :integer
           | {:integer, keyword()}
-          | :string
-          | {:string, keyword()}
           | :snowflake
-          | {atom(), atom()}
+          | {module(), atom()}
           | :emoji
+          | :any
   @type validator :: (any() -> :ok | {:error, String.t()})
+
+  @type constraint :: {:one_of, [atom()]}
 
   @spec string_length_validator(non_neg_integer(), non_neg_integer()) ::
           validator()
@@ -71,6 +129,32 @@ defmodule Mobius.Validations.ActionValidations do
     end
   end
 
+  def validate_constraints(params, constraints) do
+    errors =
+      Enum.reduce(constraints, [], fn {:one_of, options}, errors ->
+        valid? =
+          options
+          |> Enum.map(fn option -> params[option] end)
+          |> Enum.any?(fn val -> val != nil end)
+
+        if valid? do
+          errors
+        else
+          expected_options =
+            options
+            |> Enum.join(", ")
+
+          ["Expected at least one of #{expected_options} but all were missing or nil." | errors]
+        end
+      end)
+
+    if Enum.empty?(errors) do
+      :ok
+    else
+      {:error, errors}
+    end
+  end
+
   @spec validate_args(Access.t(), [{atom(), validator()}]) :: :ok | {:error, [String.t()]}
   def validate_args(params, validators) do
     errors =
@@ -102,6 +186,7 @@ defmodule Mobius.Validations.ActionValidations do
   def get_validator({:string, opts}), do: get_string_length_validator(opts)
   def get_validator({module, function}), do: fn val -> apply(module, function, [val]) end
   def get_validator(:emoji), do: emoji_validator()
+  def get_validator(:any), do: fn _ -> :ok end
 
   defp length_validator(min, max) do
     fn
@@ -135,7 +220,7 @@ defmodule Mobius.Validations.ActionValidations do
   end
 
   defp get_string_length_validator(opts) do
-    min = Keyword.fetch!(opts, :min)
+    min = Keyword.get(opts, :min, 0)
     max = Keyword.fetch!(opts, :max)
 
     string_length_validator(min, max)

--- a/lib/mobius/validations/action_validations.ex
+++ b/lib/mobius/validations/action_validations.ex
@@ -44,14 +44,14 @@ defmodule Mobius.Validations.ActionValidations do
 
   ## Constraints
 
-  Contsraints are similar to validator in that they verify that some conditions
+  Constraints are similar to validator in that they verify that some conditions
   are met. The main difference between the two is that while validators operate
   on a single parameter at a time, constraints can operate on multiple
   parameters at a time.
 
   Following is the list of available constraints.
 
-  ### {:one_of, [atom()]}
+  ### {:at_least_one_of, [atom()]}
 
   Verifies that at least one of the specified parameter was provided to the
   action.
@@ -68,7 +68,7 @@ defmodule Mobius.Validations.ActionValidations do
           | :any
   @type validator :: (any() -> :ok | {:error, String.t()})
 
-  @type constraint :: {:one_of, [atom()]}
+  @type constraint :: {:at_least_one_of, [atom()]}
 
   @spec string_length_validator(non_neg_integer(), non_neg_integer()) ::
           validator()
@@ -131,7 +131,7 @@ defmodule Mobius.Validations.ActionValidations do
 
   def validate_constraints(params, constraints) do
     errors =
-      Enum.reduce(constraints, [], fn {:one_of, options}, errors ->
+      Enum.reduce(constraints, [], fn {:at_least_one_of, options}, errors ->
         valid? =
           options
           |> Enum.map(fn option -> params[option] end)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -51,6 +51,12 @@ defmodule Mobius.Fixtures do
 
     Socket.notify_payload(data, @shard)
 
+    # Yield to give the shard time to handle the message. Not a very safe way to
+    # do this, but since there's barely anything going on during tests it works
+    # well enough.
+    Process.sleep(5)
+    assert Bot.ready?()
+
     [session_id: session_id, token: token()]
   end
 

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -71,7 +71,12 @@ defmodule Mobius.TestUtils do
       iex> assert_has_error(errors, "error 1")
       false
   """
-  @spec assert_has_error([String.t()], String.t()) :: boolean()
+  @spec assert_has_error(String.t() | [String.t()], String.t()) :: boolean()
+  def assert_has_error(error, expected_error)
+      when is_binary(error) and is_binary(expected_error) do
+    assert_has_error([error], expected_error)
+  end
+
   def assert_has_error(errors, expected_error)
       when is_list(errors) and is_binary(expected_error) do
     assert Enum.any?(errors, fn error -> error =~ expected_error end),


### PR DESCRIPTION
Part of #29

- Adds the edit_message action.
- Adds the notion of "constraints" to endpoints. Constraints are like validations, except that they can look at multiple parameters at a time instead of only one. Useful for implementing "at least on of" or "only one of" type validations.
- Adds support for multipart messages to the generic rest module. It currently assumes a `:file` option. Looking at the discord docs, it looks like `create_message` and `edit_message` are the only two endpoints that use such an option.
- Documents the different available validations and constraints for actions
- Adds a step to the action executor to check that the bot is ready.
- In the `hanshake_shard` test setup, add a small delay before returning to make sure the shard has had time to receive and handle the message telling it it's ready. Also asserts that the bot is ready.
- Allow the `assert_has_error` test helper to receive only a single error instead of a list.